### PR TITLE
Created custom hook to improve readability

### DIFF
--- a/app/(users)/profile/[USERNAME]/page.tsx
+++ b/app/(users)/profile/[USERNAME]/page.tsx
@@ -20,6 +20,7 @@ import { taglines } from "./customizationOptions";
 import { backgrounds } from "./customizationOptions";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRouter } from "next/navigation";
+import { useHasChapmanEmail } from "@/hooks/use-has-chapman-email";
 
 type Props = {
     params: { USERNAME: string }
@@ -35,7 +36,7 @@ const ProfilePage = ({ params }: Props) => {
 
     const clerkUser = useUser();
     const user = useQuery(api.users.getUserByUsername, { username: usernameSubPage });
-    const isChapmanStudent = useQuery(api.users.hasChapmanEmail, { clerkId: user?.clerkId || "" });
+    const isChapmanStudent = useHasChapmanEmail();
 
     // username editing
     const [usernameForUpdate, setUsernameForUpdate] = useState(user?.username);

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -6,7 +6,7 @@ import { useScrollTop } from "@/hooks/use-scroll-top";
 import { cn } from "@/lib/utils";
 import { Logo } from "./logo";
 import { Button } from "@/components/ui/button";
-import { useConvexAuth, useQuery } from "convex/react";
+import { useConvexAuth } from "convex/react";
 import { SignInButton, SignUpButton, UserButton } from "@clerk/nextjs";
 import { useUser } from "@clerk/clerk-react";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -16,8 +16,8 @@ import Link from "next/link";
 import Image from "next/image";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import NavbarMain from "./navbar-main";
-import { api } from "@/convex/_generated/api";
 import { useRoleCheck } from "@/hooks/use-role-check";
+import { useHasChapmanEmail } from "@/hooks/use-has-chapman-email";
 
 export const Navbar = () => {
     const { isAuthenticated, isLoading } = useConvexAuth();
@@ -25,7 +25,7 @@ export const Navbar = () => {
     const { result: isDeveloper } = useRoleCheck("developer");
     const { result: isModerator } = useRoleCheck("moderator");
     const { result: isFriend } = useRoleCheck("friend");
-    const isChapmanStudent = useQuery(api.users.hasChapmanEmail, { clerkId: user?.id || "" });
+    const isChapmanStudent = useHasChapmanEmail();
     const scrolled = useScrollTop();
     const { toast } = useToast();
 

--- a/hooks/use-has-chapman-email.tsx
+++ b/hooks/use-has-chapman-email.tsx
@@ -1,0 +1,29 @@
+import { api } from "@/convex/_generated/api";
+import { useUser } from "@clerk/nextjs";
+import { User } from "@clerk/nextjs/server";
+import { useQuery } from "convex/react";
+import { useEffect, useState } from "react";
+
+/**
+ * Custom hook to check if a user has a Chapman email.
+ *
+ * @param {User | null} [userToCheck=null] - The user object to check. If not provided, the current user will be checked.
+ * @returns {{ result: any, isLoading: boolean }} - An object containing the query result and a loading state.
+ *
+ * @example
+ * const { result, isLoading } = useHasChapmanEmail();
+ */
+export const useHasChapmanEmail = (userToCheck: User | null = null) => {
+    const { user } = useUser();
+    const clerkId = userToCheck?.id || user?.id || "";
+    const queryResult = useQuery(api.users.hasChapmanEmail, { clerkId });
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        if(queryResult !== undefined) {
+            setIsLoading(false);
+        }
+    }, [queryResult]);
+
+    return { result: queryResult, isLoading };
+};


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](www.domain-does-not-exist-yet/contibuting).
- [x] I have read and followed the [how to open a pull request guide](www.domain-does-not-exist-yet/creating-a-pull-request).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #48

<!-- Feel free to add any additional description of changes below this line -->
This pull request introduces a new custom hook, `useHasChapmanEmail`, and refactors existing components to utilize this hook. The changes aim to streamline the code and improve maintainability.

### Introduction of `useHasChapmanEmail` Hook:

* [`hooks/use-has-chapman-email.tsx`](diffhunk://#diff-a44abae23531be6423ff115f73c2927c460f645bfc9ea90eef6e2a14003b00efR1-R29): Added a custom hook to check if a user has a Chapman email. This hook leverages `useQuery` and `useEffect` to manage the query and loading state.

### Refactoring Components to Use the New Hook:

* `app/(users)/profile/[USERNAME]/page.tsx`: Replaced the existing `isChapmanStudent` query with the new `useHasChapmanEmail` hook. ([app/(users)/profile/[USERNAME]/page.tsxR23](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75R23), [app/(users)/profile/[USERNAME]/page.tsxL38-R39](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L38-R39))
* [`components/navbar.tsx`](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L9-R9): Updated the `isChapmanStudent` query to use the new `useHasChapmanEmail` hook and removed unused imports. [[1]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L9-R9) [[2]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L19-R28)