### PR TITLE
[Improvement] Profile Pictures Display Better

### DIFF
--- a/app/(users)/profile/[USERNAME]/page.tsx
+++ b/app/(users)/profile/[USERNAME]/page.tsx
@@ -24,6 +24,7 @@ import { useGetUnlockedTaglines } from "@/hooks/userProfiles/use-get-unlocked-ta
 import { useGetSelectedTagline } from "@/hooks/userProfiles/use-get-selected-tagline";
 import { useGetUnlockedBackgrounds } from "@/hooks/userProfiles/use-get-unlocked-backgrounds";
 import { useGetSelectedBackground } from "@/hooks/userProfiles/use-get-selected-background";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 type Props = {
     params: { USERNAME: string }
@@ -194,7 +195,10 @@ const ProfilePage = ({ params }: Props) => {
             <div className="flex flex-col items-center justify-center text-center gap-y-2 flex-1 px-6 pb-4 bg-background">
                 <div className="flex w-full md:flex-row flex-col md:items-start items-center justify-between px-4 md:px-10 lg:px-20">
                     <div className="flex md:flex-row flex-col items-center md:items-start md:pt-4">
-                        <Image className="rounded-full translate-y-[-5em] mb-[-5em] md:mb-0 border-8 border-background" src={user.picture} width={200} height={200} alt="Profile Picture" />
+                        <Avatar className="flex-col translate-y-[-5em] w-[200px] h-[200px] mb-[-5em] md:mb-0 border-8 border-background overflow-hidden">
+                            <AvatarFallback>{user.username[0].toUpperCase()}</AvatarFallback>
+                            <AvatarImage src={user.picture} alt={`${user.username}'s Profile Picture`} className="object-cover" />
+                        </Avatar>
                         <div className="flex flex-col items-center text-center md:text-start md:items-start justify-center gap-y-1">
                             <div className="flex md:flex-row flex-col items-center md:items-start">
                                 <div className="flex flex-row items-center">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -119,9 +119,9 @@ export const Navbar = () => {
                                             </div>
                                             { /* Toast to copy username to clipboard */}
                                             <p className="hidden sm:flex mr-2 font-bold">{user?.username}</p>
-                                            <Avatar className="w-[25px] h-[25px]">
-                                                <AvatarImage src={user?.picture} alt={`${user?.username}'s Profile Picture`} />
+                                            <Avatar className="w-[25px] h-[25px] overflow-hidden">
                                                 <AvatarFallback>{user?.username[0].toUpperCase()}</AvatarFallback>
+                                                <AvatarImage src={user?.picture} alt={`${user?.username}'s Profile Picture`} className="object-cover" />
                                             </Avatar>
                                         </div>
                                     </MenubarTrigger>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](www.domain-does-not-exist-yet/contibuting).
- [x] I have read and followed the [how to open a pull request guide](www.domain-does-not-exist-yet/creating-a-pull-request).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!-- Feel free to add any additional description of changes below this line -->
This pull request introduces changes to improve the user profile and navbar components by utilizing the `Avatar` component for better handling of user profile images and fallbacks. The changes ensure a more consistent and visually appealing display of user avatars across the application.

Improvements to user profile page:

* `app/(users)/profile/[USERNAME]/page.tsx`: Added imports for `Avatar`, `AvatarFallback`, and `AvatarImage` components. ([app/(users)/profile/[USERNAME]/page.tsxR27](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75R27))
* `app/(users)/profile/[USERNAME]/page.tsx`: Replaced the `Image` component with the `Avatar` component for displaying the user's profile picture, including fallbacks for when the picture is not available. ([app/(users)/profile/[USERNAME]/page.tsxL197-R201](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L197-R201))

Enhancements to navbar:

* [`components/navbar.tsx`](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L122-R124): Updated the `Avatar` component to include overflow handling and use the `object-cover` class for the `AvatarImage` to ensure the image is properly contained within the avatar.

**TL;DR:** I switched the profile page from showing an image to having an `Avatar,` and I made profile picture displays that only show squares and do not squish the image.