### PR TITLE
[FIX] Loading on game page after last round

### DIFF
--- a/app/(main)/game/_context/GameContext.tsx
+++ b/app/(main)/game/_context/GameContext.tsx
@@ -120,6 +120,7 @@ export const GameProvider = ({
 
     if(nextRoundNumber > levels.length) {
       setIsModalVisible(true);
+      setIsLoading(true);
       const username = user.user?.username ? user.user.username : "Anonymous";
 
       incrementDailyGameStats();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](www.domain-does-not-exist-yet/contibuting).
- [x] I have read and followed the [how to open a pull request guide](www.domain-does-not-exist-yet/creating-a-pull-request).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This pull request includes a small change to the `GameContext.tsx` file. The change ensures that the loading state is set to true when the next round number exceeds the levels length.

* [`app/(main)/game/_context/GameContext.tsx`](diffhunk://#diff-ee720b462adfb6ce798da3074c8235e7cfc4defd634fea0993e88a26f67b44aaR123): Added a line to set `isLoading` to true when `nextRoundNumber` exceeds the levels length.