### PR TITLE
[Improvement] Streak Cutoff is Now 12:00 AM PST

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -5,7 +5,7 @@ const crons = cronJobs();
 
 crons.daily(
   "Reset inactive streaks",
-  { hourUTC: 0, minuteUTC: 0 },
+  { hourUTC: 8, minuteUTC: 0 }, // 12:00am PST
   internal.users.resetInactiveStreaks
 );
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](www.domain-does-not-exist-yet/contibuting).
- [x] I have read and followed the [how to open a pull request guide](www.domain-does-not-exist-yet/creating-a-pull-request).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request includes a small but significant change to the scheduling of a cron job in the `convex/crons.ts` file. The change modifies the time at which the "Reset inactive streaks" job runs.

* [`convex/crons.ts`](diffhunk://#diff-5bd0479de0964a96cfe214667c65a2480a9248dc4ea5471fc7fbe53d0a528c08L8-R8): Updated the cron job schedule for resetting inactive streaks from 0:00 UTC to 8:00 UTC to align with 12:00am PST.