### PR TITLE
[Addition] Badge that Shows Level on Navbar

### DIFF
--- a/components/level-badge.tsx
+++ b/components/level-badge.tsx
@@ -1,0 +1,26 @@
+import Image from "next/image";
+
+interface LevelBadgeProps {
+  level: number;
+}
+
+const LevelBadge: React.FC<LevelBadgeProps> = ({ level }) => {
+  return ( 
+    <div className="hidden xs:flex items-center gap-x-2 mr-2 relative">
+      <Image
+        draggable={false} className="select-none"
+        src="/badges/level_badge.svg"
+        alt={`Account Level of ${level}`}
+        width="25"
+        height="25" 
+      />
+      <p
+        className="absolute top-1/2 left-1/2 transform -translate-x-[50%] -translate-y-[50%] text-white rounded-full px-1 text-sm font-bold drop-shadow-md"
+        style={{ textShadow: '1px 1px 0 #000, -1px -1px 0 #000, -1px 1px 0 #000, 1px -1px 0 #000' }}>
+        {level}
+      </p>
+    </div>
+  );
+};
+ 
+export default LevelBadge;

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -23,6 +23,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
 import StreakBadge from "./streak-badge";
 import { useGetSelectedTagline } from "@/hooks/userProfiles/use-get-selected-tagline";
+import LevelBadge from "./level-badge";
 
 export const Navbar = () => {
   const router = useRouter();
@@ -126,6 +127,7 @@ export const Navbar = () => {
                           <MenubarTrigger className="bg-transparent outline-none hover:bg-accent focus:bg-accent cursor-pointer">
                             <div className="flex justify-end justify-items-end items-center">
                               <StreakBadge streak={Number(user.currentStreak)} />
+                              <LevelBadge level={Number(user.level)} />
                               <p className="hidden sm:flex mr-2 font-bold">{user?.username}</p>
                               <Avatar className="w-[25px] h-[25px] overflow-hidden">
                                 <AvatarFallback>{user?.username[0].toUpperCase()}</AvatarFallback>

--- a/components/streak-badge.tsx
+++ b/components/streak-badge.tsx
@@ -6,7 +6,7 @@ interface StreakBadgeProps {
 
 const StreakBadge: React.FC<StreakBadgeProps> = ({ streak }) => {
   return ( 
-    <div className="hidden xs:flex items-center gap-x-2 mr-2 relative">
+    <div className="hidden xs:flex items-center gap-x-2 mr-1 relative">
       <Image
         draggable={false} className="select-none"
         src="/badges/streak_badge.svg"

--- a/public/badges/level_badge.svg
+++ b/public/badges/level_badge.svg
@@ -1,0 +1,18 @@
+<svg width="358" height="358" viewBox="0 0 358 358" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_19_46)">
+<path d="M196.356 29.1754C186.789 19.6082 171.273 19.6082 161.644 29.1754L29.1754 161.644C19.6082 171.211 19.6082 186.727 29.1754 196.356L161.644 328.825C171.211 338.392 186.727 338.392 196.356 328.825L328.825 196.356C338.392 186.789 338.392 171.273 328.825 161.644L196.356 29.1754Z" fill="#A50034"/>
+<path d="M158.12 25.6286L158.114 25.6342L158.109 25.6399L25.6399 158.109C14.1138 169.635 14.13 188.308 25.6286 199.88L25.6342 199.886L25.6399 199.891L158.109 332.36C169.635 343.886 188.308 343.87 199.88 332.371L199.886 332.366L199.891 332.36L332.36 199.891C343.886 188.365 343.87 169.692 332.371 158.12L332.366 158.114L332.36 158.109L199.891 25.6399C188.365 14.1138 169.692 14.13 158.12 25.6286Z" stroke="white" stroke-width="10"/>
+</g>
+<defs>
+<filter id="filter0_d_19_46" x="8" y="12" width="342" height="342" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_19_46"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_19_46" result="shape"/>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](www.domain-does-not-exist-yet/contibuting).
- [x] I have read and followed the [how to open a pull request guide](www.domain-does-not-exist-yet/creating-a-pull-request).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #101

<!-- Feel free to add any additional description of changes below this line -->

![Screenshot 2024-12-04 at 5 03 03 PM](https://github.com/user-attachments/assets/20aeb03b-a236-4b7a-b00d-dc28927c0eb4)

This pull request introduces a new `LevelBadge` component and integrates it into the existing `Navbar` component. Additionally, it includes a minor adjustment to the `StreakBadge` component's layout.

### New Component Addition:
* [`components/level-badge.tsx`](diffhunk://#diff-6f75d5678e0f3e111e31af4b1271aef52d67ed1a62b4ebf56d0422ae3ae925feR1-R26): Added a new `LevelBadge` component to display user levels with a badge icon and level number.

### Integration with Navbar:
* [`components/navbar.tsx`](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R26): Imported the new `LevelBadge` component and added it to the navbar next to the `StreakBadge` component to display user levels. [[1]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R26) [[2]](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626R130)

### Minor Adjustments:
* [`components/streak-badge.tsx`](diffhunk://#diff-6012f0cba8e783b734f92aff7804303f8600d45f8f328c73212f95148615d459L9-R9): Adjusted the margin-right value from `mr-2` to `mr-1` for better spacing in the `StreakBadge` component.