### PR TITLE
[Fix] Username Alignment on Profile Hover Card is Now Consistent on All Screen Sizes

### DIFF
--- a/components/profile-hover-card.tsx
+++ b/components/profile-hover-card.tsx
@@ -62,8 +62,8 @@ const ProfileHoverCard = ({
             <AvatarFallback>{username[0].toUpperCase()}</AvatarFallback>
           </Avatar>
           <div className="space-y-1 text-left">
-            <div className="flex md:flex-row flex-col items-center md:items-start">
-              <div className="flex flex-row items-center">
+            <div className="flex md:flex-row flex-col items-start">
+              <div className="flex flex-row items-left">
                 <h4 className="text-sm font-semibold">@{username}</h4>
                 <div className="flex flex-row items-center gap-x-2 pl-2">
                   {isDeveloperRole && (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](www.domain-does-not-exist-yet/contibuting).
- [x] I have read and followed the [how to open a pull request guide](www.domain-does-not-exist-yet/creating-a-pull-request).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request includes a small change to the `ProfileHoverCard` component in `components/profile-hover-card.tsx`. The change adjusts the alignment of elements within the component.

* [`components/profile-hover-card.tsx`](diffhunk://#diff-9a0cde96dc182a5e7020bed87e6a2c4b8824579188dc3685d62b15283564ab04L65-R66): Modified the alignment of elements from `items-center` to `items-start` and from `items-center` to `items-left` to improve the layout.

Before:
<img width="338" alt="Screenshot 2024-12-21 at 5 10 35 PM" src="https://github.com/user-attachments/assets/66325404-fcfa-465f-90a3-5478e87670fc" />

After:
<img width="362" alt="Screenshot 2024-12-21 at 5 10 25 PM" src="https://github.com/user-attachments/assets/149cc578-0af3-4416-a0e5-378c73bf3ce8" />