### PR TITLE
[fix] Interactable map recentering on new round

### DIFF
--- a/app/(main)/game/_components/interactable-map.tsx
+++ b/app/(main)/game/_components/interactable-map.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import 'leaflet/dist/leaflet.css';
-import { useEffect, useState } from 'react';
+import { MutableRefObject, useEffect, useRef, useState } from 'react';
 import L, { LatLng } from 'leaflet';
 import { CircleMarker, MapContainer, Marker, Polyline, TileLayer, useMap, useMapEvents } from 'react-leaflet';
 import { useGame } from "../_context/GameContext";
@@ -15,6 +15,7 @@ const InteractableMap = () => {
     correctLocation,
   } = useGame()!;
   const [localMarkerPosition, setLocalMarkerPosition] = useState<LatLng | null>(null);
+  const prevCorrectLocation = useRef<LatLng | null>(null);
 
   const pantherGuessrMarkerIcon = new L.Icon({
     iconUrl: '/PantherGuessrPin.svg',
@@ -81,6 +82,23 @@ const InteractableMap = () => {
     
     return null;
   }
+  
+  function CenterMapOnNewRound({ localMarkerPosition, correctLocation, prevCorrectLocation }: { localMarkerPosition: LatLng | null, correctLocation: LatLng | null, prevCorrectLocation: MutableRefObject<LatLng | null> }) {
+    const map = useMap();
+    
+    useEffect(() => {
+      if (prevCorrectLocation.current && !correctLocation) {
+        const globalCenter = new LatLng(
+          33.793332,
+          -117.851475
+        );
+        map.setView(globalCenter, 17);
+      }
+      prevCorrectLocation.current = correctLocation;
+    }, [localMarkerPosition, correctLocation, map, prevCorrectLocation]);
+    
+    return null;
+  }
     
   return (
     <div className="flex min-h-full min-w-full grow">
@@ -88,7 +106,7 @@ const InteractableMap = () => {
         className='w-full h-full rounded-md'
         attributionControl={true}
         center={[33.793332, -117.851475]}
-        zoom={16}
+        zoom={17}
         scrollWheelZoom={true}
         doubleClickZoom={true}
       >
@@ -105,6 +123,7 @@ const InteractableMap = () => {
                      */
         />
         <LocationMarker />
+        <CenterMapOnNewRound localMarkerPosition={localMarkerPosition} correctLocation={correctLocation} prevCorrectLocation={prevCorrectLocation} />
         {correctLocation && localMarkerPosition && (
           <>
             <Marker icon={correctLocationPinMarker} position={correctLocation} zIndexOffset={1000}/>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](www.domain-does-not-exist-yet/contibuting).
- [x] I have read and followed the [how to open a pull request guide](www.domain-does-not-exist-yet/creating-a-pull-request).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #122 

<!-- Feel free to add any additional description of changes below this line -->

This pull request includes several changes to the `InteractableMap` component in the `app/(main)/game/_components/interactable-map.tsx` file. The main objective is to enhance the map's behavior by centering it on a new round and adjusting the zoom level.

Enhancements to map behavior:

* Added `prevCorrectLocation` using `useRef` to track the previous correct location.
* Introduced `CenterMapOnNewRound` function to center the map on a new round if the previous correct location exists and the current correct location is null.
* Incorporated `CenterMapOnNewRound` component within the `MapContainer` to ensure the map centers appropriately on new rounds.

Code improvements:

* Imported `MutableRefObject` and `useRef` to facilitate the tracking of the previous correct location.
* Adjusted the default zoom level of the map from 16 to 17 for better visibility.