### PR TITLE
[fix] Map Component Fade In Before Load and Function Comments

### DIFF
--- a/app/(main)/game/_components/interactable-map.css
+++ b/app/(main)/game/_components/interactable-map.css
@@ -1,0 +1,14 @@
+.fade-in-map {
+  animation: fade-in 0.5s ease forwards;
+  animation-delay: 1s;
+  opacity: 0%;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0%;
+  }
+  100% {
+    opacity: 100%;
+  }
+}

--- a/app/(main)/game/_components/interactable-map.tsx
+++ b/app/(main)/game/_components/interactable-map.tsx
@@ -5,6 +5,7 @@ import { MutableRefObject, useEffect, useRef, useState } from 'react';
 import L, { LatLng } from 'leaflet';
 import { CircleMarker, MapContainer, Marker, Polyline, TileLayer, useMap, useMapEvents } from 'react-leaflet';
 import { useGame } from "../_context/GameContext";
+import "./interactable-map.css";
 
 const InteractableMap = () => {
   const {
@@ -83,6 +84,9 @@ const InteractableMap = () => {
     return null;
   }
   
+  /** 
+    * Centers the map on the correct location when the round ends
+  */
   function CenterMapOnNewRound({ localMarkerPosition, correctLocation, prevCorrectLocation }: { localMarkerPosition: LatLng | null, correctLocation: LatLng | null, prevCorrectLocation: MutableRefObject<LatLng | null> }) {
     const map = useMap();
     
@@ -101,7 +105,7 @@ const InteractableMap = () => {
   }
     
   return (
-    <div className="flex min-h-full min-w-full grow">
+    <div className="flex min-h-full min-w-full grow fade-in-map">
       <MapContainer
         className='w-full h-full rounded-md'
         attributionControl={true}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](www.domain-does-not-exist-yet/contibuting).
- [x] I have read and followed the [how to open a pull request guide](www.domain-does-not-exist-yet/creating-a-pull-request).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This pull request includes changes to enhance the visual experience and improve code documentation in the `InteractableMap` component.

### Visual Enhancements:

* Added a fade-in animation for the map component in `interactable-map.css` to create a smoother visual transition when the map loads.
* Applied the `fade-in-map` class to the map container in `interactable-map.tsx` to utilize the new fade-in animation.

### Code Documentation:

* Added a comment to the `CenterMapOnNewRound` function to describe its purpose of centering the map on the correct location when the round ends.

### Codebase Maintenance:

* Imported the new CSS file in `interactable-map.tsx` to ensure the fade-in animation is applied.
