### PR TITLE
[fix] Updated Footer Year from 2024 to 2025

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -9,7 +9,7 @@ export const Footer = () => {
   return (
     <div className="flex items-center w-full p-6 bg-transparent z-5">
       <div className="hidden md:flex md:ml-auto w-full justify-end items-center gap-x-2 text-muted-foreground">
-        <p className="text-sm mr-auto ml-2">© 2024 • PantherGuessr</p>
+        <p className="text-sm mr-auto ml-2">© 2025 • PantherGuessr</p>
         <Link href="/credits">
           <Button variant="ghost" size="sm">
             Credits
@@ -61,7 +61,7 @@ export const Footer = () => {
             </DropdownMenuSub>
           </DropdownMenuContent>
         </DropdownMenu>
-        <p className="text-sm mx-auto">© 2024 • PantherGuessr</p>
+        <p className="text-sm mx-auto">© 2025 • PantherGuessr</p>
         <ModeToggle />
       </div>
     </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](www.domain-does-not-exist-yet/contibuting).
- [x] I have read and followed the [how to open a pull request guide](www.domain-does-not-exist-yet/creating-a-pull-request).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request includes a small update to the `components/footer.tsx` file. The change updates the copyright year from 2024 to 2025.

Changes to `components/footer.tsx`:

* Updated the copyright year from 2024 to 2025 in two locations:
  * Line 9
  * Line 61

Don't merge this pull request until tonight or tomorrow.