### PR TITLE
[fixed] Avatar Image Transparency and Sizing

### DIFF
--- a/app/(marketing)/_components/desktop-heading.tsx
+++ b/app/(marketing)/_components/desktop-heading.tsx
@@ -13,6 +13,7 @@ import "./heading.css";
 import { Logo } from "@/components/logo";
 import ProfileHoverCard from "@/components/profile-hover-card";
 import LargeStreakBadge from "./_panels/large-streak-badge";
+import { Avatar, AvatarImage } from "@/components/ui/avatar";
 
 interface DesktopHeadingProps {
   username: string;
@@ -69,14 +70,15 @@ const DesktopHeading: React.FC<DesktopHeadingProps> = ({
                   background
                 )}
               >
-                <Image
-                  src={picture}
-                  className="rounded-full transition-all border-primary border-4 inset-2 hover:scale-105 my-10 drop-shadow-md cursor-pointer"
-                  alt="Profile Picture"
-                  width={100}
-                  height={100}
-                  onClick={handleGoToUserProfile}
-                />
+                <Avatar className="rounded-full transition-all border-primary bg-primary border-4 inset-2 hover:scale-105 my-10 drop-shadow-md cursor-pointer w-28 h-28">
+                  <AvatarImage
+                    src={picture}
+                    className="object-cover"
+                    alt="Profile Picture"
+                    onClick={handleGoToUserProfile}
+                  />
+
+                </Avatar>
               </div>
               <h1 className="text-3xl sm:text-3xl md:text-3xl font-bold hover:scale-105 transition-all cursor-default">
                 Welcome back, <ProfileHoverCard username={username} isUnderlined={true} />.{" " + welcomeMessage}
@@ -195,14 +197,15 @@ const DesktopHeading: React.FC<DesktopHeadingProps> = ({
                   background
                 )}
               >
-                <Image
-                  src={picture}
-                  className="rounded-full transition-all border-primary border-4 inset-2 hover:scale-105 my-10 drop-shadow-md cursor-pointer"
-                  alt="Chapman Panther Waving"
-                  width={100}
-                  height={100}
-                  onClick={handleGoToUserProfile}
-                />
+                <Avatar className="rounded-full transition-all border-primary bg-primary border-4 inset-2 hover:scale-105 my-10 drop-shadow-md cursor-pointer w-28 h-28">
+                  <AvatarImage
+                    src={picture}
+                    className="object-cover"
+                    alt="Profile Picture"
+                    onClick={handleGoToUserProfile}
+                  />
+
+                </Avatar>
               </div>
               <h1 className="text-3xl sm:text-3xl md:text-3xl font-bold cursor-default hover:scale-105 transition-all">
                 Welcome back, <ProfileHoverCard username={username} isUnderlined={true} />.{" " + welcomeMessage}

--- a/app/(users)/profile/[USERNAME]/page.tsx
+++ b/app/(users)/profile/[USERNAME]/page.tsx
@@ -277,7 +277,7 @@ const ProfilePage = ({ params }: Props) => {
               <div className="flex w-full lg:flex-row flex-col lg:items-start items-center justify-between px-4 lg:px-10 xl:px-20">
                 <div className="flex flex-col w-full lg:mr-8">
                   <div className="flex lg:flex-row flex-col items-center lg:items-start lg:pt-4 lg:mb-[-4em]">
-                    <Avatar className="flex-col translate-y-[-5em] w-[200px] h-[200px] mb-[-5em] lg:mb-0 border-8 border-background overflow-hidden">
+                    <Avatar className="flex-col translate-y-[-5em] w-[200px] h-[200px] mb-[-5em] lg:mb-0 border-8 border-background bg-background overflow-hidden">
                       <AvatarFallback>{user.username[0].toUpperCase()}</AvatarFallback>
                       <AvatarImage
                         src={user.picture}


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](pantherguessr.com/contibuting).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

- Changes the main header to use the `Avatar` component, ensuring image size consistency regardless of profile picture.
- Added background color behind image for both the header page and profile page, ensuring that transparent profile pictures do not show the elements behind these two `Avatar` components.


### Screenshots

<img width="195" height="155" alt="image" src="https://github.com/user-attachments/assets/ab9a455a-a047-444a-9a3e-19efeca5664f" />
<img width="276" height="270" alt="image" src="https://github.com/user-attachments/assets/3072ad0f-95d8-46af-b88e-57f678981209" />

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [fixed] Avatar Image Sizing and Transparency