### PR TITLE
[fixed] Multi Select is Unselectable

### DIFF
--- a/app/(developer)/admin/_levels/_helpers/levelupload.tsx
+++ b/app/(developer)/admin/_levels/_helpers/levelupload.tsx
@@ -186,6 +186,7 @@ const LevelUpload = () => {
                 variant="inverted"
                 animation={0}
                 maxCount={3}
+                renderInPlace
               />
             </div>
             <div className="flex w-full h-80 grow py-2">

--- a/app/(users)/profile/[USERNAME]/_components/AdministrativeActions.tsx
+++ b/app/(users)/profile/[USERNAME]/_components/AdministrativeActions.tsx
@@ -384,6 +384,7 @@ const ProfileAdministrativeActions = ({
                           variant="inverted"
                           animation={0}
                           className="w-full"
+                          renderInPlace
                         />
                       </div>
                     </div>


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](pantherguessr.com/contibuting).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #184

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This pull request updates the `MultiSelect` UI component to allow its popover content to be rendered directly in the DOM tree instead of in a portal, addressing issues when the component is used inside modals or dialogs. The change introduces a new `renderInPlace` prop and applies this option in two places where `MultiSelect` is used. The implementation includes a new `NonPortalPopoverContent` component and updates prop handling and documentation.

**MultiSelect component enhancements:**

* Added a new `renderInPlace` prop to `MultiSelect`, allowing popover content to be rendered in-place rather than in a portal, which is useful for usage inside modals or dialogs. [[1]](diffhunk://#diff-e19b3e0b8dfec03d5d8d295fcba3fae7420e855e827fc866d4c2b04a41de73dcL1-R2)10R110, [[2]](diffhunk://#diff-e19b3e0b8dfec03d5d8d295fcba3fae7420e855e827fc866d4c2b04a41de73dcL1-R2)29R129)
* Implemented `NonPortalPopoverContent` and logic to select between portaled or in-place popover content based on the `renderInPlace` prop. [[1]](diffhunk://#diff-e19b3e0b8dfec03d5d8d295fcba3fae7420e855e827fc866d4c2b04a41de73dcL18-R37) [[2]](diffhunk://#diff-e19b3e0b8dfec03d5d8d295fcba3fae7420e855e827fc866d4c2b04a41de73dcL1-R2)39R139)
* Updated prop documentation and cleaned up unused comments in `multi-select.tsx`. (F39d97beL62R62, [components/ui/multi-select.tsxL1-R2](diffhunk://#diff-e19b3e0b8dfec03d5d8d295fcba3fae7420e855e827fc866d4c2b04a41de73dcL1-R2)10R110)

**Usage updates:**

* Enabled the `renderInPlace` option in `LevelUpload` and `ProfileAdministrativeActions` components to fix popover display issues in their respective contexts. ([app/(developer)/admin/_levels/_helpers/levelupload.tsxR189](diffhunk://#diff-fadd749eb8da818c3a9f4f907e18e6fed5a1e9a8d79d88ff590be55f3c2282beR189), [app/(users)/profile/[USERNAME]/_components/AdministrativeActions.tsxR387](diffhunk://#diff-b59d2473b9c4092a4bbf36d7b7f1de4cd3e17222bf4a1ce8d0d01f6510b010ddR387))

**Codebase maintenance:**

* Removed an outdated file header comment from `multi-select.tsx`.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
https://github.com/user-attachments/assets/a0d928cf-ef43-43aa-88cd-64afeb98bcdf

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [fixed] Multiselect dropdown is now clickable
