### PR TITLE
[refactor] Replace heic-convert with heic2any for image conversion

### DIFF
--- a/app/(developer)/admin/_levels/_helpers/levelupload.tsx
+++ b/app/(developer)/admin/_levels/_helpers/levelupload.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useUser } from "@clerk/nextjs";
 import imageCompression from "browser-image-compression";
 import { useMutation } from "convex/react";
-import convert from "heic-convert";
+import heic2any from "heic2any";
 import { CarFront, House, LoaderCircle, Plus, Store, University } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -75,11 +75,15 @@ const LevelUpload = () => {
       // Convert HEIC to JPEG or PNG if necessary
       if (selectedImage.type === "image/heic" || selectedImage.type === "image/heif") {
         imageConverted = true;
-        convertedBuffer = await convert({
-          buffer: Buffer.from(imageBuffer), // the HEIC file buffer
-          format: "JPEG", // output format (change to 'PNG' if needed)
-          quality: 1, // the jpeg compression quality, between 0 and 1
+        const convertedBlob = await heic2any({
+          blob: selectedImage,
+          toType: "image/jpeg",
+          quality: 0.9,
         });
+        // checks to see if blobs may be an array (should not be but here for safety)
+        const finalBlob = Array.isArray(convertedBlob) ? convertedBlob[0] : convertedBlob;
+        // creates chosen image file 
+        chosenImage = new File([finalBlob], selectedImage.name.replace(/\.[^/.]+$/, ".jpg"), { type: "image/jpeg" });
       }
 
       // only change the file if it was converted

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "cmdk": "^1.1.1",
         "convex": "^1.25.4",
         "date-fns": "^4.1.0",
-        "heic-convert": "^2.1.0",
+        "heic2any": "^0.0.4",
         "html2canvas-pro": "^1.5.8",
         "leaflet": "^2.0.0-alpha",
         "lucide-react": "^0.447.0",
@@ -8242,31 +8242,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/heic-convert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/heic-convert/-/heic-convert-2.1.0.tgz",
-      "integrity": "sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg==",
-      "license": "ISC",
-      "dependencies": {
-        "heic-decode": "^2.0.0",
-        "jpeg-js": "^0.4.4",
-        "pngjs": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/heic-decode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-2.0.0.tgz",
-      "integrity": "sha512-NU+zsiDvdL+EebyTjrEqjkO2XYI7FgLhQzsbmO8dnnYce3S0PBSDm/ZyI4KpcGPXYEdb5W72vp/AQFuc4F8ASg==",
-      "license": "ISC",
-      "dependencies": {
-        "libheif-js": "^1.17.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/html2canvas-pro": {
       "version": "1.5.8",
@@ -8848,12 +8828,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/jpeg-js": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/js-cookie": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
@@ -9002,15 +8976,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/libheif-js": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.18.2.tgz",
-      "integrity": "sha512-4Nk0dKhhRfVS4mECcX2jSDpNU6gcHQLneJjkGQq61N8COGtjSpSA3CI+1Q3kUYv5Vf+SwIqUtaDSdU6JO37c6w==",
-      "license": "LGPL-3.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/lilconfig": {
@@ -10075,15 +10040,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cmdk": "^1.1.1",
     "convex": "^1.25.4",
     "date-fns": "^4.1.0",
-    "heic-convert": "^2.1.0",
+    "heic2any": "^0.0.4",
     "html2canvas-pro": "^1.5.8",
     "leaflet": "^2.0.0-alpha",
     "lucide-react": "^0.447.0",


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](pantherguessr.com/contibuting).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #162 

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

- This updates the project to use the [heic2any](https://alexcorvi.github.io/heic2any/) package instead of `heic-convert` to convert `.heic` images to `.jpeg` format.
- This is because `heic-convert` is intended to run within a node.js server environment, meaning it is not supported to run within a web browser on the client side. `heic2any` specifically supports client-side image conversion.

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
