### PR TITLE
[improvement] /weekly now redirects to leaderboard if already done

### DIFF
--- a/app/(main)/weekly/page.tsx
+++ b/app/(main)/weekly/page.tsx
@@ -2,36 +2,53 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useQuery } from "convex/react";
 import { LoaderCircle } from "lucide-react";
 
-import Spinner from "@/components/spinner";
+import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
+import { useLeaderboardByGameUser } from "@/hooks/use-leaderboard-by-game-user";
 import { useWeeklyChallengeGameId } from "@/hooks/use-weekly-challenge-id";
 
 export default function WeeklyPage() {
   const router = useRouter();
   const gameId = useWeeklyChallengeGameId();
 
-  useEffect(() => {
-    if (gameId) {
-      router.replace(`/game/${gameId}`);
-    }
-  }, [gameId, router]);
+  // Get current user
+  const currentUser = useQuery(api.users.current);
 
-  if (gameId === null) {
+  // Get leaderboard entry for this weekly game and user
+  // You may want to handle loading state for currentUser if needed
+  const currentUserId = currentUser?._id as Id<"users"> | undefined;
+
+  // Get leaderboard entry for this weekly game and user using the new hook
+  const leaderboardEntry = useLeaderboardByGameUser(gameId ? (gameId as Id<"games">) : undefined, currentUserId);
+
+  useEffect(() => {
+    // wait for gameId, currentUserId, and leaderboardEntry to load
+    if (!gameId) return;
+    if (!currentUserId) return;
+    if (leaderboardEntry === undefined) return;
+
+    // redirect to results if completed weekly challenge
+    if (leaderboardEntry && leaderboardEntry._id) {
+      router.replace(`/results/game/${gameId}`);
+      return;
+    }
+    // otherwise redirect to game page
+    router.replace(`/game/${gameId}`);
+  }, [gameId, leaderboardEntry, currentUserId, router]);
+
+  // show loading elements while waiting
+  if (!gameId || !currentUserId || leaderboardEntry === undefined) {
     return (
-      // should never be nonexistent
       <div className="w-full h-full min-h-screen flex flex-col p-8 text-center items-center justify-center gap-4">
-        <p className="text-xl">Finding weekly challenge...</p>
+        <p className="text-xl">Loading weekly challenge...</p>
         <LoaderCircle className="animate-spin" size={72} />
       </div>
     );
   }
 
-  // show loading challenge
-  return (
-    <div className="w-full h-full min-h-screen flex flex-col p-8 text-center items-center justify-center gap-4">
-      <p className="text-xl">Loading weekly challenge...</p>
-      <LoaderCircle className="animate-spin" size={72} />
-    </div>
-  );
+  // shouldn't ever reach but here just in case
+  return null;
 }

--- a/hooks/use-leaderboard-by-game-user.ts
+++ b/hooks/use-leaderboard-by-game-user.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "convex/react";
+
+import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
+
+/**
+ * Custom hook to get the leaderboard entry for a specific game ID and user ID.
+ * Returns the leaderboard entry or null if not found.
+ *
+ * @param gameId - The ID of the game
+ * @param userId - The ID of the user
+ */
+export function useLeaderboardByGameUser(gameId?: Id<"games">, userId?: Id<"users">) {
+  return useQuery(api.game.getLeaderboardEntryByGameAndUser, gameId && userId ? { gameId, userId } : "skip");
+}

--- a/hooks/use-weekly-challenge-id.tsx
+++ b/hooks/use-weekly-challenge-id.tsx
@@ -2,15 +2,16 @@ import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 
 import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
 
 /**
  * Custom hook to get the currently active weekly challenge game ID, and create one if not found
  * @returns gameId (string) or null if not found
  */
-export function useWeeklyChallengeGameId(): string | null {
+export function useWeeklyChallengeGameId(): Id<"games"> | null {
   const weeklyChallenge = useQuery(api.weeklychallenge.getWeeklyChallenge, {});
   const createWeeklyChallenge = useMutation(api.weeklychallenge.makeWeeklyChallengeIfNonexistent);
-  const [gameId, setGameId] = useState<string | null>(null);
+  const [gameId, setGameId] = useState<Id<"games"> | null>(null);
   const [challengeCreated, setChallengeCreated] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](pantherguessr.com/contibuting).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

- `/weekly` now has a check for whether the user has played the current weekly challenge, minimizing the loading redirects and times (and theoretically reducing API usage). It now immediately redirects to the weekly leaderboard page if the user has completed the weekly challenge.

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [improved] Weekly Challenge redirects to leaderboard immediately if already done
