### PR TITLE
[refactor] Removed username usage on leaderboard entries

### DIFF
--- a/app/(main)/game/_context/GameContext.tsx
+++ b/app/(main)/game/_context/GameContext.tsx
@@ -193,9 +193,6 @@ export const GameProvider = ({ children, gameId }: { children: React.ReactNode; 
         userClerkId: user?.user?.id ?? "",
       });
 
-      // gets username for leaderboard entry
-      const username = user.user?.username ? user.user.username : "Anonymous";
-
       // !!! it may be a bad idea to assume this is never null but, ya know, YOLO! - Dylan
       updateStreak({ clerkId: currentUser!.clerkId });
 
@@ -203,7 +200,6 @@ export const GameProvider = ({ children, gameId }: { children: React.ReactNode; 
 
       addLeaderboardEntryToGame({
         gameId: gameData!.gameContent!._id,
-        username: username,
         userId: currentUser!._id,
         round_1: BigInt(allScores[0]),
         round_1_distance: BigInt(allDistances[0]),

--- a/app/(main)/results/[leaderboardID]/page.tsx
+++ b/app/(main)/results/[leaderboardID]/page.tsx
@@ -20,6 +20,7 @@ import { api } from "@/convex/_generated/api";
 import { useBanCheck } from "@/hooks/use-ban-check";
 
 import { cn } from "@/lib/utils";
+import useUserById from "@/hooks/use-user-by-id";
 
 type Props = {
   params: Promise<{ leaderboardID: string }>;
@@ -63,6 +64,7 @@ const ResultPage = ({ params }: Props) => {
 
   useEffect(() => {
     if (leaderboardEntry) {
+
       setDistances([
         Number(leaderboardEntry.round_1_distance),
         Number(leaderboardEntry.round_2_distance),
@@ -84,7 +86,7 @@ const ResultPage = ({ params }: Props) => {
         Number(leaderboardEntry.round_4) +
         Number(leaderboardEntry.round_5);
       setFinalScore(totalScore);
-      setUsername(leaderboardEntry.username);
+      setUsername(user ? user.username : "Unknown Player");
       setOldLevel(Number(leaderboardEntry.oldLevel));
       setNewLevel(Number(leaderboardEntry.newLevel));
     }

--- a/app/(main)/results/[leaderboardID]/page.tsx
+++ b/app/(main)/results/[leaderboardID]/page.tsx
@@ -18,9 +18,9 @@ import { Separator } from "@/components/ui/separator";
 import { api } from "@/convex/_generated/api";
 
 import { useBanCheck } from "@/hooks/use-ban-check";
+import useUserById from "@/hooks/use-user-by-id";
 
 import { cn } from "@/lib/utils";
-import useUserById from "@/hooks/use-user-by-id";
 
 type Props = {
   params: Promise<{ leaderboardID: string }>;
@@ -33,6 +33,8 @@ const ResultPage = ({ params }: Props) => {
   const searchParams = useSearchParams();
   const { leaderboardID } = use(params);
   const leaderboardEntry = useQuery(api.game.getPersonalLeaderboardEntryById, { id: leaderboardID });
+  // fetch the user document for this leaderboard entry by userId
+  const user = useUserById(leaderboardEntry?.userId);
   const [distances, setDistances] = useState<number[]>([]);
   const [scores, setScores] = useState<number[]>([]);
   const [finalScore, setFinalScore] = useState<number>(0);
@@ -64,7 +66,6 @@ const ResultPage = ({ params }: Props) => {
 
   useEffect(() => {
     if (leaderboardEntry) {
-
       setDistances([
         Number(leaderboardEntry.round_1_distance),
         Number(leaderboardEntry.round_2_distance),
@@ -86,11 +87,12 @@ const ResultPage = ({ params }: Props) => {
         Number(leaderboardEntry.round_4) +
         Number(leaderboardEntry.round_5);
       setFinalScore(totalScore);
-      setUsername(user ? user.username : "Unknown Player");
+      // prefer fetching username from the user document referenced by userId
+      setUsername(user?.username ?? "");
       setOldLevel(Number(leaderboardEntry.oldLevel));
       setNewLevel(Number(leaderboardEntry.newLevel));
     }
-  }, [leaderboardEntry]);
+  }, [leaderboardEntry, user]);
 
   useEffect(() => {
     if (isFromGame && leaderboardEntry) {

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -250,7 +250,6 @@ export const getGameById = query({
 export const addLeaderboardEntryToGame = mutation({
   args: {
     gameId: v.id("games"),
-    username: v.string(),
     userId: v.id("users"),
     round_1: v.int64(),
     round_1_distance: v.int64(),
@@ -278,14 +277,13 @@ export const addLeaderboardEntryToGame = mutation({
     );
 
     const xpResult: { newLevel: bigint; oldLevel: bigint } = await ctx.runMutation(internal.users.awardUserXP, {
-      username: args.username,
+      userID: args.userId,
       earnedXP: newXP,
     });
 
     // make leaderboard entry
     const leaderboardEntry = await ctx.db.insert("leaderboardEntries", {
       game: args.gameId,
-      username: args.username,
       oldLevel: xpResult.oldLevel,
       newLevel: xpResult.newLevel,
       userId: args.userId,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -66,7 +66,6 @@ export default defineSchema({
 
   leaderboardEntries: defineTable({
     game: v.union(v.id("games"), v.id("weeklyChallenges")),
-    username: v.string(),
     oldLevel: v.int64(),
     newLevel: v.int64(),
     userId: v.id("users"),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -197,12 +197,12 @@ export const isUserBanned = query({
  */
 export const awardUserXP = internalMutation({
   args: {
-    username: v.string(),
+    userID: v.id("users"),
     earnedXP: v.number(),
   },
   async handler(ctx, args) {
-    // Retrieve the user by their username
-    const user = await userByUsername(ctx, args.username);
+    // Retrieve the user by their ID
+    const user = await ctx.db.get(args.userID);
     if (!user) {
       throw new Error("User not found");
     }
@@ -233,7 +233,7 @@ export const awardUserXP = internalMutation({
       }
     } while (canLevelUp);
 
-    console.log(`Awarded @${args.username} ${args.earnedXP} XP`);
+    console.log(`Awarded @${args.userID} ${args.earnedXP} XP`);
 
     // Update the user's level and current XP in the database
     await ctx.db.patch(user._id, { level, currentXP });

--- a/hooks/use-user-by-id.tsx
+++ b/hooks/use-user-by-id.tsx
@@ -1,0 +1,29 @@
+import { useUser } from "@clerk/nextjs";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useEffect, useRef, useState } from "react";
+
+import { api } from "@/convex/_generated/api";
+import { Doc, Id } from "@/convex/_generated/dataModel";
+
+interface GameData {
+  gameContent: Doc<"games">;
+  startingRound?: number;
+  startingScores?: number[];
+  startingDistances?: number[];
+}
+
+const useUserById = (userId?: Id<"users">) => {
+  const [userData, setUserData] = useState<Doc<"users"> | null>(null);
+
+  const fetchUser = useQuery(api.users.getUserById, userId ? { id: userId } : "skip");
+
+  useEffect(() => {
+    if (fetchUser) {
+      setUserData(fetchUser);
+    }
+  }, [fetchUser]);
+
+  return userData;
+};
+
+export default useUserById;

--- a/hooks/use-user-by-id.tsx
+++ b/hooks/use-user-by-id.tsx
@@ -1,16 +1,8 @@
-import { useUser } from "@clerk/nextjs";
-import { useConvexAuth, useMutation, useQuery } from "convex/react";
-import { useEffect, useRef, useState } from "react";
+import { useQuery } from "convex/react";
+import { useEffect, useState } from "react";
 
 import { api } from "@/convex/_generated/api";
 import { Doc, Id } from "@/convex/_generated/dataModel";
-
-interface GameData {
-  gameContent: Doc<"games">;
-  startingRound?: number;
-  startingScores?: number[];
-  startingDistances?: number[];
-}
 
 const useUserById = (userId?: Id<"users">) => {
   const [userData, setUserData] = useState<Doc<"users"> | null>(null);


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #120

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

- Leaderboard entries no longer have a 'username' field
- Instead the results page now pulls the username using the userId value of the leaderboard entry

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [improved] Leaderboard entries will match user's name when changed
