### PR TITLE
[improve] Profile Hover Card Font Weight Consistency Fix

### DIFF
--- a/components/profile-hover-card.tsx
+++ b/components/profile-hover-card.tsx
@@ -136,10 +136,10 @@ const ProfileHoverCard = ({ userID, username, hasAtSymbol = true, isUnderlined =
                 </div>
               </div>
             </div>
-            <p className="text-sm text-muted-foreground italic">{profileTagline?.tagline}</p>
+            <p className="text-sm font-bold text-muted-foreground italic">{profileTagline?.tagline}</p>
             <div className="flex items-center pt-2">
               <CalendarDays className="mr-2 h-4 w-4 opacity-70" />{" "}
-              <span className="text-xs text-muted-foreground">
+              <span className="text-xs font-bold text-muted-foreground">
                 Joined{" "}
                 {new Date(user?._creationTime ?? "").toLocaleDateString("en-US", {
                   year: "numeric",


### PR DESCRIPTION
Added font-bold styling to the profile tagline and join date text in ProfileHoverCard to improve visual emphasis.

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This pull request makes minor UI improvements to the `ProfileHoverCard` component by updating the visual styling of text elements to improve emphasis and readability.

* UI enhancements:
  * Made the profile tagline text bold by adding the `font-bold` class to the `<p>` element displaying `profileTagline?.tagline`.
  * Made the "Joined" date text bold by adding the `font-bold` class to the `<span>` element showing the user's join date.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Before:
<img width="406" height="248" alt="Screenshot 2025-09-16 at 9 00 00 PM" src="https://github.com/user-attachments/assets/064d495c-bb2c-46e8-b2ef-761f401527f2" />

After:
<img width="429" height="263" alt="Screenshot 2025-09-16 at 8 59 43 PM" src="https://github.com/user-attachments/assets/414e918a-6558-42cf-adc9-840e679e1fcb" />

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [improved] Profile hover card now has consistent font weight
