### PR TITLE
[added] Show Gamemode on Game Results Receipt

### DIFF
--- a/app/(main)/results/[leaderboardID]/page.tsx
+++ b/app/(main)/results/[leaderboardID]/page.tsx
@@ -2,7 +2,18 @@
 
 import { useQuery } from "convex/react";
 import html2canvas from "html2canvas-pro";
-import { ArrowRight, Download, Gamepad2, Home, ListOrdered, Loader2, Share, Share2 } from "lucide-react";
+import {
+  ArrowRight,
+  Calendar,
+  Download,
+  Gamepad2,
+  Home,
+  ListOrdered,
+  Loader2,
+  Share,
+  Share2,
+  User,
+} from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -38,6 +49,7 @@ const ResultPage = ({ params }: Props) => {
   const [distances, setDistances] = useState<number[]>([]);
   const [scores, setScores] = useState<number[]>([]);
   const [finalScore, setFinalScore] = useState<number>(0);
+  const [gameType, setGameType] = useState<string>("");
   const [username, setUsername] = useState<string>("");
   const [oldLevel, setOldLevel] = useState<number>(0);
   const [newLevel, setNewLevel] = useState<number>(0);
@@ -91,6 +103,7 @@ const ResultPage = ({ params }: Props) => {
       setUsername(user?.username ?? "");
       setOldLevel(Number(leaderboardEntry.oldLevel));
       setNewLevel(Number(leaderboardEntry.newLevel));
+      setGameType(leaderboardEntry.gameType);
     }
   }, [leaderboardEntry, user]);
 
@@ -160,7 +173,7 @@ const ResultPage = ({ params }: Props) => {
     }
   };
 
-  if (!leaderboardEntry || isBanCheckLoading) {
+  if (!leaderboardEntry || isBanCheckLoading || !username) {
     return (
       <div className="min-h-full flex flex-col">
         <div className="flex flex-col items-center justify-center text-center gap-y-8 flex-1 px-6 pb-10">
@@ -198,7 +211,22 @@ const ResultPage = ({ params }: Props) => {
               <Separator />
               <div className="flex flex-col space-y-4">
                 <div className="p-2">
-                  <div className="flex flex-row justify-between">
+                  <div className="text-lg flex flex-row bg-secondary justify-items-center justify-center items-center p-2 w-full rounded-md gap-x-2">
+                    {gameType === "weekly" ? (
+                      <Calendar className="w-5 h-5" />
+                    ) : gameType === "singleplayer" ? (
+                      <User className="w-5 h-5" />
+                    ) : null}
+                    <div className="">
+                      {gameType === "weekly" ? "Weekly Challenge" : gameType === "singleplayer" ? "Singleplayer" : null}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <Separator />
+              <div className="flex flex-col space-y-4">
+                <div className="p-2">
+                  <div className="flex flex-row justify-between pb-2">
                     <h2 className="font-bold">Guessr Information</h2>
                   </div>
                   <div className="flex flex-row justify-between">


### PR DESCRIPTION
Adds visual indicators and labels for 'weekly' and 'singleplayer' game types using icons and text. Updates state management to include gameType and ensures username is loaded before rendering results.

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #196

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This pull request updates the `ResultPage` to display the game type (either "Weekly Challenge" or "Singleplayer") more clearly to users and improves the loading state logic. The changes introduce new UI elements for game type and ensure that the page only renders once all necessary user information is available.

**User experience improvements:**

* Added a new section to the results page that visually displays the game type using icons (`Calendar` for weekly challenges and `User` for singleplayer), along with descriptive labels. ([app/(main)/results/[leaderboardID]/page.tsxL201-R229](diffhunk://#diff-e49123dbea182005ccefece36417452cde2afe7ce6c0dfda0f0b616cb11b2ffaL201-R229))
* Introduced a new state variable `gameType` and set its value based on the leaderboard entry data to support the new UI section. ([app/(main)/results/[leaderboardID]/page.tsxR52](diffhunk://#diff-e49123dbea182005ccefece36417452cde2afe7ce6c0dfda0f0b616cb11b2ffaR52), [app/(main)/results/[leaderboardID]/page.tsxR106](diffhunk://#diff-e49123dbea182005ccefece36417452cde2afe7ce6c0dfda0f0b616cb11b2ffaR106))

**Loading logic improvements:**

* Updated the loading condition to ensure the page only renders after both the leaderboard entry and username are loaded, preventing incomplete UI states. ([app/(main)/results/[leaderboardID]/page.tsxL163-R176](diffhunk://#diff-e49123dbea182005ccefece36417452cde2afe7ce6c0dfda0f0b616cb11b2ffaL163-R176))

**Dependency updates:**

* Imported new icons (`Calendar`, `User`) from `lucide-react` to support the game type visual indicators. ([app/(main)/results/[leaderboardID]/page.tsxL5-R16](diffhunk://#diff-e49123dbea182005ccefece36417452cde2afe7ce6c0dfda0f0b616cb11b2ffaL5-R16))

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="700" height="2110" alt="image" src="https://github.com/user-attachments/assets/cc737c6d-fd10-46ef-ab1e-57e2fdf85514" />
<img width="700" height="2110" alt="image" src="https://github.com/user-attachments/assets/837243e3-477f-4307-b6db-96f693f8a87e" />

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [added] Gamemode now shows on game results page
