### PR TITLE
[fixed] Profile pic now centered on heading

### DIFF
--- a/app/(marketing)/_components/desktop-heading.tsx
+++ b/app/(marketing)/_components/desktop-heading.tsx
@@ -70,7 +70,7 @@ const DesktopHeading: React.FC<DesktopHeadingProps> = ({
                   background
                 )}
               >
-                <Avatar className="rounded-full transition-all border-primary bg-primary border-4 inset-2 hover:scale-105 my-10 drop-shadow-md cursor-pointer w-28 h-28">
+                <Avatar className="rounded-full transition-all border-primary bg-primary border-4 hover:scale-105 my-10 drop-shadow-md cursor-pointer w-28 h-28">
                   <AvatarImage
                     src={picture}
                     className="object-cover"
@@ -199,7 +199,7 @@ const DesktopHeading: React.FC<DesktopHeadingProps> = ({
                   background
                 )}
               >
-                <Avatar className="rounded-full transition-all border-primary bg-primary border-4 inset-2 hover:scale-105 my-10 drop-shadow-md cursor-pointer w-28 h-28">
+                <Avatar className="rounded-full transition-all border-primary bg-primary border-4 hover:scale-105 my-10 drop-shadow-md cursor-pointer w-28 h-28">
                   <AvatarImage
                     src={picture}
                     className="object-cover"


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

- Removed `inset-2` from profile pic and banner combo on the heading, making it centered.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="474" height="376" alt="image" src="https://github.com/user-attachments/assets/3bb2f395-64a8-4d8f-ab9e-f93141e5a2aa" />

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [fixed] Centered profile pic on front page