### PR TITLE
[fix] Prevent image dragging in sidebar magnifier

### DIFF
--- a/app/(main)/game/_components/in-game-sidebar.tsx
+++ b/app/(main)/game/_components/in-game-sidebar.tsx
@@ -315,7 +315,8 @@ const InGameSidebar = () => {
               onMouseEnter={handleMouseEnter}
               onMouseMove={handleMouseMoveMagnifier}
               onMouseLeave={handleMouseLeave}
-              className="rounded-md"
+              draggable={false}
+              className="rounded-md select-none"
             />
           )}
         </div>


### PR DESCRIPTION
Added draggable={false} and select-none to the image element in the in-game sidebar to prevent unwanted dragging and selection when interacting with the magnifier.

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This pull request introduces a minor UI improvement to the `InGameSidebar` component to enhance user experience when interacting with images.

* Prevents the image from being draggable and disables text selection by adding the `draggable={false}` attribute and the `select-none` class to the image element.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: N/A
