### PR TITLE
[improvement] Guesses with distance further than screen width, now scales map accordingly

### DIFF
--- a/app/(main)/game/_components/interactable-map.tsx
+++ b/app/(main)/game/_components/interactable-map.tsx
@@ -75,11 +75,18 @@ const InteractableMap = () => {
 
     useEffect(() => {
       if (localMarkerPosition && correctLocation) {
-        const midpoint = new LatLng(
-          (localMarkerPosition.lat + correctLocation.lat) / 2,
-          (localMarkerPosition.lng + correctLocation.lng) / 2
+        map.fitBounds(
+          [
+            [localMarkerPosition.lat, localMarkerPosition.lng],
+            [correctLocation.lat, correctLocation.lng],
+          ],
+          {
+            padding: [50, 50],
+            maxZoom: 18,
+            animate: true,
+            duration: 0.5,
+          }
         );
-        map.setView(midpoint, map.getZoom());
       }
     }, [localMarkerPosition, correctLocation, map]);
 

--- a/app/(main)/game/_components/interactable-map.tsx
+++ b/app/(main)/game/_components/interactable-map.tsx
@@ -75,7 +75,7 @@ const InteractableMap = () => {
 
     useEffect(() => {
       if (localMarkerPosition && correctLocation) {
-        map.fitBounds(
+        map.flyToBounds(
           [
             [localMarkerPosition.lat, localMarkerPosition.lng],
             [correctLocation.lat, correctLocation.lng],


### PR DESCRIPTION
Replaces centering the map on the midpoint with fitting bounds between the local marker and the correct location. Adds padding, max zoom, and animation for a better user experience.

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This pull request updates the map behavior in the `InteractableMap` component to improve how the map view adjusts when both the user's marker and the correct location are set. Instead of simply centering between the two points, the map now automatically zooms and pans to fit both locations within view, providing a better user experience.

Map interaction improvements:

* Changed the map adjustment logic to use `map.fitBounds` with padding and animation, ensuring both the user's marker and the correct location are visible and optimally framed.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [improvement] Correct guess line is more responsive