### PR TITLE
[fix + add] Removed second create level button + new levels count display

### DIFF
--- a/app/(developer)/admin/_levels/levels.tsx
+++ b/app/(developer)/admin/_levels/levels.tsx
@@ -278,7 +278,7 @@ const Levels = () => {
 
   return (
     <>
-      <LevelUpload />
+      <p className="text-start">{tableData?.length || 0} total levels.</p>
       <DataTable columns={columns} data={tableData || []} />
     </>
   );


### PR DESCRIPTION
Removed the LevelUpload component and added a paragraph showing the total number of levels in the Levels admin page.

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This pull request makes a small UI update to the `Levels` admin page. The change adds a summary line showing the total number of levels above the data table.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="1155" height="374" alt="Screenshot 2025-10-02 at 1 45 00 PM" src="https://github.com/user-attachments/assets/e58bbeba-0f4c-4ec3-994c-ccb08369309e" />

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: n/a