### PR TITLE
[improvement] Admin level panel sorting and deletion

### DIFF
--- a/app/(developer)/admin/_levels/_helpers/datatable.tsx
+++ b/app/(developer)/admin/_levels/_helpers/datatable.tsx
@@ -28,10 +28,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  initialSorting?: SortingState;
 }
 
-export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>([]);
+export function DataTable<TData, TValue>({ columns, data, initialSorting = [] }: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = useState<SortingState>(initialSorting);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 

--- a/app/(developer)/admin/_levels/levels.tsx
+++ b/app/(developer)/admin/_levels/levels.tsx
@@ -2,7 +2,7 @@
 
 import { ColumnDef } from "@tanstack/react-table";
 import { useMutation, useQuery } from "convex/react";
-import { ArrowUpDown, MoreHorizontal } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, MoreHorizontal } from "lucide-react";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useEffect, useState } from "react";
@@ -185,7 +185,7 @@ const Levels = () => {
         return (
           <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
             Title
-            <ArrowUpDown className="ml-2 h-4 w-4" />
+            {column.getIsSorted() === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />}
           </Button>
         );
       },
@@ -196,7 +196,7 @@ const Levels = () => {
         return (
           <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
             Tags
-            <ArrowUpDown className="ml-2 h-4 w-4" />
+            {column.getIsSorted() === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />}
           </Button>
         );
       },
@@ -210,7 +210,7 @@ const Levels = () => {
         return (
           <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
             Times Played
-            <ArrowUpDown className="ml-2 h-4 w-4" />
+            {column.getIsSorted() === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />}
           </Button>
         );
       },

--- a/app/(developer)/admin/_levels/levels.tsx
+++ b/app/(developer)/admin/_levels/levels.tsx
@@ -2,7 +2,7 @@
 
 import { ColumnDef } from "@tanstack/react-table";
 import { useMutation, useQuery } from "convex/react";
-import { ArrowDown, ArrowUp, ArrowUpDown, MoreHorizontal } from "lucide-react";
+import { ArrowDown, ArrowUp, MoreHorizontal } from "lucide-react";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useEffect, useState } from "react";
@@ -183,7 +183,7 @@ const Levels = () => {
       accessorKey: "title",
       header: ({ column }) => {
         return (
-          <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+          <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")} className={column.getIsSorted() ? "font-bold text-primary" : ""}>
             Title
             {column.getIsSorted() === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />}
           </Button>
@@ -194,7 +194,7 @@ const Levels = () => {
       accessorKey: "tags",
       header: ({ column }) => {
         return (
-          <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+          <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")} className={column.getIsSorted() ? "font-bold text-primary" : ""}>
             Tags
             {column.getIsSorted() === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />}
           </Button>
@@ -208,7 +208,7 @@ const Levels = () => {
       accessorKey: "_creationTime",
       header: ({ column }) => {
         return (
-          <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+          <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")} className={column.getIsSorted() ? "font-bold text-primary" : ""}>
             Created
             {column.getIsSorted() === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />}
           </Button>
@@ -294,7 +294,7 @@ const Levels = () => {
   return (
     <>
       <p className="text-start">{tableData?.length || 0} total levels.</p>
-      <DataTable columns={columns} data={tableData || []} />
+      <DataTable columns={columns} data={tableData || []} initialSorting={[{ id: "_creationTime", desc: true }]} />
     </>
   );
 };

--- a/app/(developer)/admin/_levels/levels.tsx
+++ b/app/(developer)/admin/_levels/levels.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { ArrowUpDown, MoreHorizontal } from "lucide-react";
 import dynamic from "next/dynamic";
 import Image from "next/image";
@@ -63,6 +63,7 @@ const Levels = () => {
   // convex api functions
   const tableData = useQuery(api.admin.getAllLevels);
   const imageSrc = useQuery(api.admin.getImageSrcByLevelId, clickedLevelId ? { id: clickedLevelId } : "skip");
+  const deleteLevel = useMutation(api.levelcreator.deleteLevelById);
 
   // sets the image source to default on table data load
   useEffect(() => {
@@ -265,7 +266,11 @@ const Levels = () => {
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="text-red-600 dark:text-red-500"
-                onClick={() => alert("Sorry, delete level action not implemented yet.")}
+                onClick={() => {
+                  if (window.confirm("Are you sure you want to delete this level?")) {
+                    deleteLevel({ levelId: level._id });
+                  }
+                }}
               >
                 Delete
               </DropdownMenuItem>

--- a/app/(developer)/admin/_levels/levels.tsx
+++ b/app/(developer)/admin/_levels/levels.tsx
@@ -205,15 +205,25 @@ const Levels = () => {
       },
     },
     {
-      accessorKey: "timesPlayed",
+      accessorKey: "_creationTime",
       header: ({ column }) => {
         return (
           <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-            Times Played
+            Created
             {column.getIsSorted() === "asc" ? <ArrowUp className="ml-2 h-4 w-4" /> : <ArrowDown className="ml-2 h-4 w-4" />}
           </Button>
         );
       },
+      cell: (cell) => {
+        const date = new Date(cell.row.original._creationTime);
+        return date.toLocaleString(
+          undefined,
+          {
+            year: "numeric", month: "numeric", day: "numeric",
+            hour: "2-digit", minute: "2-digit"
+          }
+        );
+      }
     },
     {
       accessorKey: "imageId",

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -8,7 +8,9 @@ import { query } from "./_generated/server";
  */
 export const getAllLevels = query({
   handler: async (ctx) => {
+    // get levels and sort from newest to oldest
     const levels = await ctx.db.query("levels").collect();
+    levels.sort((a, b) => (a._creationTime > b._creationTime ? -1 : 1));
 
     return levels;
   },

--- a/convex/levelcreator.ts
+++ b/convex/levelcreator.ts
@@ -39,3 +39,20 @@ export const createLevelWithImageStorageId = mutation({
     });
   },
 });
+
+/**
+ * Deletes a level by its ID and the associated image from storage
+ * @param args.levelId - The ID of the level to delete
+ */
+export const deleteLevelById = mutation({
+  args: {
+    levelId: v.id("levels"),
+  },
+  handler: async (ctx, args) => {
+    const level = await ctx.db.get(args.levelId);
+    if (level) {
+      await ctx.storage.delete(level.imageId);
+      await ctx.db.delete(args.levelId);
+    }
+  },
+});


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request introduces several improvements to the admin levels table, focusing on enhanced sorting, improved UI feedback, and new backend functionality for deleting levels. The most significant changes include updating the table to sort by creation time by default, refining the sorting UI, and implementing the ability to delete levels (and their associated images) from both the frontend and backend.

**Table UI and Sorting Improvements:**

* The `DataTable` component now accepts an `initialSorting` prop, allowing the table to default to sorting by the `_creationTime` field in descending order. [[1]](diffhunk://#diff-7b55894aa9599506a163198a4ea419ae6b14bf657e48afc5bd9f9e25c913c52aR31-R35) [[2]](diffhunk://#diff-d1f514c267be1510d7fc2be4f0f60857357658e781037798b2d36f00291142e6L282-R297)
* The sorting icons in the table headers have been updated to display an up or down arrow based on the current sort direction, and the active column is highlighted for better user feedback. [[1]](diffhunk://#diff-d1f514c267be1510d7fc2be4f0f60857357658e781037798b2d36f00291142e6L185-R188) [[2]](diffhunk://#diff-d1f514c267be1510d7fc2be4f0f60857357658e781037798b2d36f00291142e6L196-R199) [[3]](diffhunk://#diff-d1f514c267be1510d7fc2be4f0f60857357658e781037798b2d36f00291142e6L207-R226)
* The "Created" column now displays the creation date in a human-readable format, as times played wasn't too important.

**Level Deletion Functionality:**

* Added a `deleteLevelById` mutation on the backend, which deletes both the level and its associated image from storage.
* The frontend now uses this mutation to allow admins to delete levels via the table UI, with a confirmation prompt for safety. [[1]](diffhunk://#diff-d1f514c267be1510d7fc2be4f0f60857357658e781037798b2d36f00291142e6R66) [[2]](diffhunk://#diff-d1f514c267be1510d7fc2be4f0f60857357658e781037798b2d36f00291142e6L268-R283)

**Backend Data Handling:**

* The `getAllLevels` query now sorts levels from newest to oldest by default, ensuring consistent ordering across the admin UI.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="1482" height="775" alt="image" src="https://github.com/user-attachments/assets/c6e2ad4d-4b13-4c6f-9626-09d877e5a232" />
<img width="1481" height="766" alt="image" src="https://github.com/user-attachments/assets/d514b915-d321-4a35-a7ea-53e10493408e" />

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
