### PR TITLE
[fix] Internal `timesPlayed` tracker now updates correctly

### DIFF
--- a/convex/game.ts
+++ b/convex/game.ts
@@ -506,41 +506,16 @@ export const checkGuess = mutation({
     console.log("Correct: " + correctLat + " " + correctLng);
     console.log("User Guess: " + args.guessLatitude + " " + args.guessLongitude);
 
+    await ctx.db.patch(args.id, {
+      timesPlayed: (level.timesPlayed ?? BigInt(0)) + BigInt(1)
+    });
+
     return {
       correctLat,
       correctLng,
       distanceAway,
       score,
     };
-  },
-});
-
-/**
- * Updates the timesPlayed field for a level //TODO: Fix this to enable it to work
- *
- * @param args.id - The ID of the level to update
- * @returns Object indicating success/failure of updating the timesPlayed field
- */
-export const updateTimesPlayed = mutation({
-  args: { id: v.id("levels") },
-  handler: async (ctx, args) => {
-    const level = await ctx.db.get(args.id);
-
-    if (!level) {
-      throw new Error("No levels exist");
-    }
-
-    const timesPlayed = (level.timesPlayed ?? BigInt(0)) + BigInt(1);
-
-    // update level
-    const newLevel = {
-      ...level,
-      timesPlayed,
-    };
-
-    await ctx.db.replace(args.id, newLevel);
-
-    return { success: true };
   },
 });
 


### PR DESCRIPTION
The timesPlayed field is now incremented directly within the checkGuess mutation, eliminating the need for the separate updateTimesPlayed mutation, which has been removed for clarity and maintainability.

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #221

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This pull request simplifies how the `timesPlayed` field is updated for a level in the game logic. The update now happens directly within the `checkGuess` mutation, and the separate `updateTimesPlayed` mutation has been removed to streamline the codebase.

**Game logic improvements:**

* The `checkGuess` mutation now directly increments the `timesPlayed` field for the relevant level each time a guess is checked, ensuring the play count is always updated in real time.

**Codebase cleanup:**

* The redundant `updateTimesPlayed` mutation and its related code have been removed, reducing unnecessary complexity and potential for errors.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

https://github.com/user-attachments/assets/fecb3020-90a9-4029-bffc-77c7eb2888f0

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: n/a
