### PR TITLE
[improvement] HEIC image conversion fallback where possible

### DIFF
--- a/app/(developer)/admin/_levels/_helpers/levelupload.tsx
+++ b/app/(developer)/admin/_levels/_helpers/levelupload.tsx
@@ -84,7 +84,7 @@ const LevelUpload = () => {
         fileName.endsWith(".heif");
 
       if (isHeicOrHeif) {
-        let convertedBlob: Blob | null = null;
+        let convertedBlob!: Blob;
 
         try {
           const result = await heic2any({ blob: selectedImage, toType: "image/jpeg", quality: 0.9 });

--- a/app/(developer)/admin/_levels/_helpers/levelupload.tsx
+++ b/app/(developer)/admin/_levels/_helpers/levelupload.tsx
@@ -84,15 +84,32 @@ const LevelUpload = () => {
         fileName.endsWith(".heif");
 
       if (isHeicOrHeif) {
-        const convertedBlob = await heic2any({
-          blob: selectedImage,
-          toType: "image/jpeg",
-          quality: 0.9,
-        });
+        let convertedBlob: Blob | null = null;
 
-        const finalBlob = Array.isArray(convertedBlob) ? convertedBlob[0] : convertedBlob;
+        try {
+          const result = await heic2any({ blob: selectedImage, toType: "image/jpeg", quality: 0.9 });
+          convertedBlob = Array.isArray(result) ? result[0] : result;
+        } catch {
+          // heic2any fails on some HEIC variants, tries to use native browser decoding
+          try {
+            const bitmap = await createImageBitmap(selectedImage);
+            const canvas = document.createElement("canvas");
+            canvas.width = bitmap.width;
+            canvas.height = bitmap.height;
+            const ctx = canvas.getContext("2d");
+            if (!ctx) throw new Error("Could not get canvas context");
+            ctx.drawImage(bitmap, 0, 0);
+            convertedBlob = await new Promise<Blob>((resolve, reject) => {
+              canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("Canvas toBlob failed"))), "image/jpeg", 0.9);
+            });
+          } catch {
+            throw new Error(
+              "This HEIC/HEIF image could not be converted automatically. Please convert it to JPEG or PNG first and re-upload, or try another browser."
+            );
+          }
+        }
 
-        fileToProcess = new File([finalBlob], selectedImage.name.replace(/\.[^/.]+$/, ".jpg"), { type: "image/jpeg" });
+        fileToProcess = new File([convertedBlob], selectedImage.name.replace(/\.[^/.]+$/, ".jpg"), { type: "image/jpeg" });
       }
 
       // image compression options
@@ -163,7 +180,7 @@ const LevelUpload = () => {
               <Input
                 id="picture"
                 type="file"
-                accept="image/png, image/jpg, image/jpeg, image/heic, image/heif"
+                accept="image/png, image/jpeg, image/heic, image/heif, .png, .jpg, .jpeg, .heic, .heif"
                 ref={imageInput}
                 onChange={(event) => setSelectedImage(event.target.files?.[0] || null)}
               />

--- a/app/(developer)/admin/_levels/_helpers/levelupload.tsx
+++ b/app/(developer)/admin/_levels/_helpers/levelupload.tsx
@@ -100,7 +100,11 @@ const LevelUpload = () => {
             if (!ctx) throw new Error("Could not get canvas context");
             ctx.drawImage(bitmap, 0, 0);
             convertedBlob = await new Promise<Blob>((resolve, reject) => {
-              canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("Canvas toBlob failed"))), "image/jpeg", 0.9);
+              canvas.toBlob(
+                (blob) => (blob ? resolve(blob) : reject(new Error("Canvas toBlob failed"))),
+                "image/jpeg",
+                0.9
+              );
             });
           } catch {
             throw new Error(
@@ -109,7 +113,9 @@ const LevelUpload = () => {
           }
         }
 
-        fileToProcess = new File([convertedBlob], selectedImage.name.replace(/\.[^/.]+$/, ".jpg"), { type: "image/jpeg" });
+        fileToProcess = new File([convertedBlob], selectedImage.name.replace(/\.[^/.]+$/, ".jpg"), {
+          type: "image/jpeg",
+        });
       }
 
       // image compression options

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -32,7 +32,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/components/ui/multi-select.tsx
+++ b/components/ui/multi-select.tsx
@@ -60,7 +60,8 @@ const multiSelectVariants = cva(
  * Props for MultiSelect component
  */
 interface MultiSelectProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof multiSelectVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof multiSelectVariants> {
   options: {
     /** The text to display for the option. */
     label: string;

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -50,7 +50,8 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>, VariantProps<typeof sheetVariants> {}
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
   ({ side = "right", className, children, ...props }, ref) => (


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

Wraps heic2any conversion in try/catch and adds a fallback that uses createImageBitmap + canvas.toBlob to handle HEIC/HEIF variants that heic2any fails on. Throws an error if both conversions fail. Preserve output as a JPEG File with a .jpg extension. Also expand the file input accept list to include explicit extensions (.png, .jpg, .jpeg, .heic, .heif) and normalize MIME types.


## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: 
[fixed] Small bugfixes to level image uploading