### PR TITLE
[refactor] Restructure Taglines and Profile Backgrounds Storage

### DIFF
--- a/app/(users)/profile/[USERNAME]/_components/ProfileBackground.tsx
+++ b/app/(users)/profile/[USERNAME]/_components/ProfileBackground.tsx
@@ -3,7 +3,6 @@ import { PenLine } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Id } from "@/convex/_generated/dataModel";
 import { cn } from "@/lib/utils";
 
 interface ProfileBackgroundProps {
@@ -13,8 +12,7 @@ interface ProfileBackgroundProps {
   setIsEditingBackground: (value: boolean) => void;
   unlockedProfileBackgrounds?:
     | ({
-        _id: Id<"profileBackgrounds">;
-        _creationTime: number;
+        id: string;
         title: string;
         backgroundCSS: string;
       } | null)[]
@@ -22,9 +20,9 @@ interface ProfileBackgroundProps {
     | undefined;
   userClerkId: string;
   setBackgroundCSSValue: (value: string) => void;
-  setBackgroundIdForUpdate: Dispatch<SetStateAction<Id<"profileBackgrounds"> | undefined>>;
-  backgroundIdForUpdate: Id<"profileBackgrounds"> | undefined;
-  updateSelectedBackground: (value: { clerkId: string; backgroundId: Id<"profileBackgrounds"> }) => void;
+  setBackgroundIdForUpdate: Dispatch<SetStateAction<string | undefined>>;
+  backgroundIdForUpdate: string | undefined;
+  updateSelectedBackground: (value: { clerkId: string; backgroundId: string }) => void;
 }
 
 const ProfileBackground = ({
@@ -54,22 +52,22 @@ const ProfileBackground = ({
                   <div className="grid max-h-24 grid-flow-row grid-cols-2 gap-4 overflow-y-scroll md:max-h-48 md:grid-cols-3">
                     {unlockedProfileBackgrounds?.map((background) => (
                       <div
-                        key={background?._id}
+                        key={background?.id}
                         className={cn(
                           "bg-gradient-red-purple flex h-20 w-32 cursor-pointer items-center justify-center rounded-md",
                           background?.backgroundCSS
                         )}
                         onClick={() => {
                           setBackgroundCSSValue(background!.backgroundCSS);
-                          setBackgroundIdForUpdate(background!._id);
+                          setBackgroundIdForUpdate(background!.id);
                           updateSelectedBackground({
                             clerkId: userClerkId,
-                            backgroundId: background!._id,
+                            backgroundId: background!.id,
                           });
                           setIsEditingBackground(false);
                         }}
                       >
-                        {background?._id == backgroundIdForUpdate && <p className="text-sm text-white">Selected</p>}
+                        {background?.id == backgroundIdForUpdate && <p className="text-sm text-white">Selected</p>}
                       </div>
                     ))}
                   </div>

--- a/app/(users)/profile/[USERNAME]/page.tsx
+++ b/app/(users)/profile/[USERNAME]/page.tsx
@@ -74,7 +74,7 @@ const ProfilePage = ({ params }: Props) => {
 
   // tagline editing
   const [taglineForUpdate, setTaglineForUpdate] = useState(profile?.selectedTagline?.tagline);
-  const [taglineIdForUpdate, setTaglineIdForUpdate] = useState(profile?.selectedTagline?._id);
+  const [taglineIdForUpdate, setTaglineIdForUpdate] = useState(profile?.selectedTagline?.id);
   const [isEditingTagline, setIsEditingTagline] = useState(false);
   const [taglinePopoverOpen, setTaglinePopoverOpen] = useState(false);
 
@@ -83,7 +83,7 @@ const ProfilePage = ({ params }: Props) => {
   const [backgroundCSSValue, setBackgroundCSSValue] = useState<string | undefined>(
     profile?.selectedBackground?.backgroundCSS
   );
-  const [backgroundIdForUpdate, setBackgroundIdForUpdate] = useState(profile?.selectedBackground?._id);
+  const [backgroundIdForUpdate, setBackgroundIdForUpdate] = useState(profile?.selectedBackground?.id);
   const [prevSelectedBackground, setPrevSelectedBackground] = useState(profile?.selectedBackground);
 
   // page reloading effect that is just a CSS class change
@@ -94,7 +94,7 @@ const ProfilePage = ({ params }: Props) => {
     setPrevSelectedBackground(profile?.selectedBackground);
     if (profile?.selectedBackground && !isEditingBackground) {
       setBackgroundCSSValue(profile.selectedBackground.backgroundCSS);
-      setBackgroundIdForUpdate(profile.selectedBackground._id);
+      setBackgroundIdForUpdate(profile.selectedBackground.id);
     }
   }
 
@@ -421,13 +421,13 @@ const ProfilePage = ({ params }: Props) => {
                                       <CommandGroup>
                                         {unlockedProfileTaglines?.map((tagline) => (
                                           <CommandItem
-                                            key={tagline?._id}
+                                            key={tagline?.id}
                                             value={tagline?.tagline}
                                             onSelect={(currentValue) => {
                                               setTaglineForUpdate(
                                                 currentValue === taglineForUpdate ? "" : currentValue
                                               );
-                                              setTaglineIdForUpdate(tagline?._id);
+                                              setTaglineIdForUpdate(tagline?.id);
                                               setTaglinePopoverOpen(false);
                                             }}
                                           >
@@ -454,7 +454,7 @@ const ProfilePage = ({ params }: Props) => {
                               <Save
                                 className="ml-1 mt-1 h-5 w-5 cursor-pointer"
                                 onClick={() => {
-                                  if (taglineIdForUpdate !== profileTagline?._id) {
+                                  if (taglineIdForUpdate !== profileTagline?.id) {
                                     updateSelectedTagline({
                                       clerkId: user.clerkId,
                                       taglineId: taglineIdForUpdate!,

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as gamestats from "../gamestats.js";
 import type * as http from "../http.js";
 import type * as leaderboard from "../leaderboard.js";
 import type * as levelcreator from "../levelcreator.js";
+import type * as migrations from "../migrations.js";
 import type * as reports from "../reports.js";
 import type * as users from "../users.js";
 import type * as weeklychallenge from "../weeklychallenge.js";
@@ -37,6 +38,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   leaderboard: typeof leaderboard;
   levelcreator: typeof levelcreator;
+  migrations: typeof migrations;
   reports: typeof reports;
   users: typeof users;
   weeklychallenge: typeof weeklychallenge;

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,0 +1,141 @@
+import { internalMutation } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+import { PROFILE_BACKGROUNDS, DEFAULT_BACKGROUND_ID } from "../lib/backgrounds";
+import { PROFILE_TAGLINES, DEFAULT_TAGLINE_ID } from "../lib/taglines";
+
+/**
+ * One-time migration: converts users' profileTagline and profileBackground fields
+ * from Convex document IDs (pointing to the now-deprecated profileTaglines /
+ * profileBackgrounds tables) to plain string IDs defined in the library files.
+ * Also backfills every starter tagline and background into existing users' inventories.
+ *
+ * Run once via the Convex dashboard or CLI:
+ *   npx convex run migrations:migrateTaglinesAndBackgrounds
+ *
+ * After all users are migrated you can safely delete the profileTaglines and
+ * profileBackgrounds table definitions from convex/schema.ts and clear their
+ * data from the Convex dashboard.
+ */
+export const migrateTaglinesAndBackgrounds = internalMutation({
+  args: {},
+  async handler(ctx) {
+    const bgByCss = Object.fromEntries(PROFILE_BACKGROUNDS.map((b) => [b.backgroundCSS, b.id]));
+    const taglineByText = Object.fromEntries(PROFILE_TAGLINES.map((t) => [t.tagline, t.id]));
+    const allLibraryTaglineIds = new Set(PROFILE_TAGLINES.map((t) => t.id));
+    const allLibraryBgIds = new Set(PROFILE_BACKGROUNDS.map((b) => b.id));
+
+    const starterTaglineIds = PROFILE_TAGLINES.filter((t) => t.tier === "starter").map((t) => t.id);
+    const starterBgIds = PROFILE_BACKGROUNDS.filter((b) => b.tier === "starter").map((b) => b.id);
+
+    function slugify(text: string): string {
+      return text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "_")
+        .replace(/^_|_$/g, "")
+        .slice(0, 64);
+    }
+
+    const users = await ctx.db.query("users").collect();
+    let migrated = 0;
+
+    for (const user of users) {
+      let newTagline: string | undefined;
+      let newBackground: string | undefined;
+      let newUnlockedTaglines: string[] | undefined;
+      let newUnlockedBackgrounds: string[] | undefined;
+
+      // --- profileTagline: convert old Convex ID → library string ID ---
+      const rawTaglineId = user.profileTagline;
+      if (!allLibraryTaglineIds.has(rawTaglineId)) {
+        const taglineDoc = await ctx.db.get(rawTaglineId as Id<"profileTaglines">).catch(() => null);
+        if (taglineDoc && "tagline" in taglineDoc) {
+          const text = (taglineDoc as { tagline: string }).tagline;
+          newTagline = taglineByText[text] ?? slugify(text);
+        }
+      }
+
+      // --- profileBackground: convert old Convex ID → library string ID ---
+      const rawBgId = user.profileBackground;
+      if (!allLibraryBgIds.has(rawBgId)) {
+        const bgDoc = await ctx.db.get(rawBgId as Id<"profileBackgrounds">).catch(() => null);
+        if (bgDoc && "backgroundCSS" in bgDoc) {
+          const css = (bgDoc as { backgroundCSS: string }).backgroundCSS;
+          newBackground = bgByCss[css] ?? css;
+        }
+      }
+
+      // --- unlockedProfileTaglines: convert IDs, then backfill all starter taglines ---
+      const migratedTaglines: string[] = [];
+      let anyTaglineChanged = false;
+      for (const id of user.unlockedProfileTaglines) {
+        if (allLibraryTaglineIds.has(id)) {
+          migratedTaglines.push(id);
+        } else {
+          anyTaglineChanged = true;
+          const doc = await ctx.db.get(id as Id<"profileTaglines">).catch(() => null);
+          if (doc && "tagline" in doc) {
+            const text = (doc as { tagline: string }).tagline;
+            migratedTaglines.push(taglineByText[text] ?? slugify(text));
+          } else {
+            migratedTaglines.push(id);
+          }
+        }
+      }
+      for (const starterId of starterTaglineIds) {
+        if (!migratedTaglines.includes(starterId)) {
+          migratedTaglines.push(starterId);
+          anyTaglineChanged = true;
+        }
+      }
+      if (anyTaglineChanged) newUnlockedTaglines = migratedTaglines;
+
+      // --- unlockedProfileBackgrounds: convert IDs, then backfill all starter backgrounds ---
+      const migratedBgs: string[] = [];
+      let anyBgChanged = false;
+      for (const id of user.unlockedProfileBackgrounds) {
+        if (allLibraryBgIds.has(id)) {
+          migratedBgs.push(id);
+        } else {
+          anyBgChanged = true;
+          const doc = await ctx.db.get(id as Id<"profileBackgrounds">).catch(() => null);
+          if (doc && "backgroundCSS" in doc) {
+            const css = (doc as { backgroundCSS: string }).backgroundCSS;
+            migratedBgs.push(bgByCss[css] ?? css);
+          } else {
+            migratedBgs.push(id);
+          }
+        }
+      }
+      for (const starterId of starterBgIds) {
+        if (!migratedBgs.includes(starterId)) {
+          migratedBgs.push(starterId);
+          anyBgChanged = true;
+        }
+      }
+      if (anyBgChanged) newUnlockedBackgrounds = migratedBgs;
+
+      // If the active tagline/background didn't survive conversion, reset to defaults
+      const resolvedTagline = newTagline ?? user.profileTagline;
+      if (!allLibraryTaglineIds.has(resolvedTagline)) {
+        newTagline = DEFAULT_TAGLINE_ID;
+      }
+      const resolvedBg = newBackground ?? user.profileBackground;
+      if (!allLibraryBgIds.has(resolvedBg)) {
+        newBackground = DEFAULT_BACKGROUND_ID;
+      }
+
+      const hasChanges = newTagline || newBackground || newUnlockedTaglines || newUnlockedBackgrounds;
+      if (hasChanges) {
+        await ctx.db.patch(user._id, {
+          ...(newTagline !== undefined && { profileTagline: newTagline }),
+          ...(newBackground !== undefined && { profileBackground: newBackground }),
+          ...(newUnlockedTaglines !== undefined && { unlockedProfileTaglines: newUnlockedTaglines }),
+          ...(newUnlockedBackgrounds !== undefined && { unlockedProfileBackgrounds: newUnlockedBackgrounds }),
+        });
+        migrated++;
+      }
+    }
+
+    return `Migrated ${migrated} of ${users.length} users.`;
+  },
+});

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,5 +1,4 @@
 import { internalMutation } from "./_generated/server";
-import { Id } from "./_generated/dataModel";
 import { PROFILE_BACKGROUNDS, DEFAULT_BACKGROUND_ID } from "../lib/backgrounds";
 import { PROFILE_TAGLINES, DEFAULT_TAGLINE_ID } from "../lib/taglines";
 
@@ -47,7 +46,7 @@ export const migrateTaglinesAndBackgrounds = internalMutation({
       // --- profileTagline: convert old Convex ID → library string ID ---
       const rawTaglineId = user.profileTagline;
       if (!allLibraryTaglineIds.has(rawTaglineId)) {
-        const taglineDoc = await ctx.db.get(rawTaglineId as Id<"profileTaglines">).catch(() => null);
+        const taglineDoc = await (ctx.db as any).get(rawTaglineId).catch(() => null);
         if (taglineDoc && "tagline" in taglineDoc) {
           const text = (taglineDoc as { tagline: string }).tagline;
           newTagline = taglineByText[text] ?? slugify(text);
@@ -57,7 +56,7 @@ export const migrateTaglinesAndBackgrounds = internalMutation({
       // --- profileBackground: convert old Convex ID → library string ID ---
       const rawBgId = user.profileBackground;
       if (!allLibraryBgIds.has(rawBgId)) {
-        const bgDoc = await ctx.db.get(rawBgId as Id<"profileBackgrounds">).catch(() => null);
+        const bgDoc = await (ctx.db as any).get(rawBgId).catch(() => null);
         if (bgDoc && "backgroundCSS" in bgDoc) {
           const css = (bgDoc as { backgroundCSS: string }).backgroundCSS;
           newBackground = bgByCss[css] ?? css;
@@ -72,7 +71,7 @@ export const migrateTaglinesAndBackgrounds = internalMutation({
           migratedTaglines.push(id);
         } else {
           anyTaglineChanged = true;
-          const doc = await ctx.db.get(id as Id<"profileTaglines">).catch(() => null);
+          const doc = await (ctx.db as any).get(id).catch(() => null);
           if (doc && "tagline" in doc) {
             const text = (doc as { tagline: string }).tagline;
             migratedTaglines.push(taglineByText[text] ?? slugify(text));
@@ -97,7 +96,7 @@ export const migrateTaglinesAndBackgrounds = internalMutation({
           migratedBgs.push(id);
         } else {
           anyBgChanged = true;
-          const doc = await ctx.db.get(id as Id<"profileBackgrounds">).catch(() => null);
+          const doc = await (ctx.db as any).get(id).catch(() => null);
           if (doc && "backgroundCSS" in doc) {
             const css = (doc as { backgroundCSS: string }).backgroundCSS;
             migratedBgs.push(bgByCss[css] ?? css);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -17,10 +17,10 @@ export default defineSchema({
     banAppeal: v.optional(v.id("banAppeals")),
     achievements: v.optional(v.array(v.object({ id: v.string(), unlockedAt: v.number() }))),
     picture: v.string(),
-    profileTagline: v.id("profileTaglines"),
-    profileBackground: v.id("profileBackgrounds"),
-    unlockedProfileTaglines: v.array(v.id("profileTaglines")),
-    unlockedProfileBackgrounds: v.array(v.id("profileBackgrounds")),
+    profileTagline: v.string(),
+    profileBackground: v.string(),
+    unlockedProfileTaglines: v.array(v.string()),
+    unlockedProfileBackgrounds: v.array(v.string()),
   })
     .index("byClerkId", ["clerkId"])
     .index("byUsername", ["username"])

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -101,17 +101,6 @@ export default defineSchema({
     .index("byUserClerkId", ["userClerkId"])
     .index("byGame", ["game"]),
 
-  profileTaglines: defineTable({
-    tagline: v.string(),
-    locked: v.optional(v.boolean()),
-  }),
-
-  profileBackgrounds: defineTable({
-    title: v.string(),
-    backgroundCSS: v.string(),
-    locked: v.optional(v.boolean()),
-  }),
-
   userReports: defineTable({
     reportedUser: v.id("users"),
     reporter: v.id("users"),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -4,6 +4,8 @@ import { v, Validator } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
 import { internalAction, internalMutation, mutation, MutationCtx, query, QueryCtx } from "./_generated/server";
+import { PROFILE_BACKGROUNDS, PROFILE_BACKGROUNDS_MAP, DEFAULT_BACKGROUND_ID } from "../lib/backgrounds";
+import { PROFILE_TAGLINES, PROFILE_TAGLINES_MAP, DEFAULT_TAGLINE_ID } from "../lib/taglines";
 
 /**
  * Retrieves a user from the database using their Convex ID.
@@ -101,10 +103,6 @@ export const current = query({
  *
  * @returns {Promise<void>} - A promise that resolves when the upsert operation is complete.
  */
-function pickRandom<T>(arr: T[], n: number): T[] {
-  const shuffled = [...arr].sort(() => Math.random() - 0.5);
-  return shuffled.slice(0, Math.min(n, arr.length));
-}
 
 export const upsertFromClerk = internalMutation({
   args: { data: v.any() as Validator<UserJSON> }, // no runtime validation, trust Clerk
@@ -112,18 +110,8 @@ export const upsertFromClerk = internalMutation({
     const user = await userByClerkId(ctx, data.id);
 
     if (user === null) {
-      const allTaglines = await ctx.db.query("profileTaglines").collect();
-      const unlockedTaglines = allTaglines.filter((t) => !t.locked);
-      if (unlockedTaglines.length === 0) throw new Error("No unlocked taglines available for new user assignment");
-
-      const allBackgrounds = await ctx.db.query("profileBackgrounds").collect();
-      const unlockedBackgrounds = allBackgrounds.filter((b) => !b.locked);
-      if (unlockedBackgrounds.length === 0) throw new Error("No unlocked backgrounds available for new user assignment");
-
-      const pickedTaglines = pickRandom(unlockedTaglines, 3);
-      const pickedBackgrounds = pickRandom(unlockedBackgrounds, 3);
-      const activeTagline = pickedTaglines[Math.floor(Math.random() * pickedTaglines.length)];
-      const activeBackground = pickedBackgrounds[Math.floor(Math.random() * pickedBackgrounds.length)];
+      const starterTaglines = PROFILE_TAGLINES.filter((t) => t.tier === "starter");
+      const starterBackgrounds = PROFILE_BACKGROUNDS.filter((b) => b.tier === "starter");
 
       const userAttributes = {
         clerkId: data.id!,
@@ -134,10 +122,10 @@ export const upsertFromClerk = internalMutation({
         currentStreak: 0n,
         isBanned: false,
         picture: data.image_url,
-        profileBackground: activeBackground._id,
-        profileTagline: activeTagline._id,
-        unlockedProfileBackgrounds: pickedBackgrounds.map((b) => b._id),
-        unlockedProfileTaglines: pickedTaglines.map((t) => t._id),
+        profileTagline: DEFAULT_TAGLINE_ID,
+        profileBackground: DEFAULT_BACKGROUND_ID,
+        unlockedProfileTaglines: starterTaglines.map((t) => t.id),
+        unlockedProfileBackgrounds: starterBackgrounds.map((b) => b.id),
       };
 
       await ctx.db.insert("users", userAttributes);
@@ -428,19 +416,9 @@ export const getUnlockedTaglines = query({
       return null;
     }
 
-    const taglineIds = user?.unlockedProfileTaglines;
-
-    // iterate through taglines to return objects
-    const taglines = [];
-    for (const taglineId of taglineIds) {
-      const tagline = await ctx.db
-        .query("profileTaglines")
-        .withIndex("by_id", (q) => q.eq("_id", taglineId))
-        .unique();
-      taglines.push(tagline);
-    }
-
-    return taglines;
+    return user.unlockedProfileTaglines
+      .map((id) => PROFILE_TAGLINES_MAP[id] ?? null)
+      .filter(Boolean);
   },
 });
 
@@ -467,14 +445,7 @@ export const getSelectedTagline = query({
       return null;
     }
 
-    const taglineId = user?.profileTagline;
-
-    const tagline = await ctx.db
-      .query("profileTaglines")
-      .withIndex("by_id", (q) => q.eq("_id", taglineId))
-      .unique();
-
-    return tagline;
+    return PROFILE_TAGLINES_MAP[user.profileTagline] ?? null;
   },
 });
 
@@ -496,7 +467,7 @@ export const getSelectedTagline = query({
 export const updateSelectedTagline = mutation({
   args: {
     clerkId: v.string(),
-    taglineId: v.id("profileTaglines"),
+    taglineId: v.string(),
   },
   async handler(ctx, args) {
     const user = await userByClerkId(ctx, args.clerkId);
@@ -520,18 +491,9 @@ export const getUnlockedBackgrounds = query({
       return null;
     }
 
-    const backgroundIds = user?.unlockedProfileBackgrounds;
-
-    const backgrounds = [];
-    for (const backgroundId of backgroundIds) {
-      const background = await ctx.db
-        .query("profileBackgrounds")
-        .withIndex("by_id", (q) => q.eq("_id", backgroundId))
-        .unique();
-      backgrounds.push(background);
-    }
-
-    return backgrounds;
+    return user.unlockedProfileBackgrounds
+      .map((id) => PROFILE_BACKGROUNDS_MAP[id] ?? null)
+      .filter(Boolean);
   },
 });
 
@@ -546,21 +508,14 @@ export const getSelectedBackground = query({
       return null;
     }
 
-    const backgroundId = user?.profileBackground;
-
-    const background = await ctx.db
-      .query("profileBackgrounds")
-      .withIndex("by_id", (q) => q.eq("_id", backgroundId))
-      .unique();
-
-    return background;
+    return PROFILE_BACKGROUNDS_MAP[user.profileBackground] ?? null;
   },
 });
 
 export const updateSelectedBackground = mutation({
   args: {
     clerkId: v.string(),
-    backgroundId: v.id("profileBackgrounds"),
+    backgroundId: v.string(),
   },
   async handler(ctx, args) {
     const user = await userByClerkId(ctx, args.clerkId);
@@ -570,6 +525,46 @@ export const updateSelectedBackground = mutation({
     }
 
     await ctx.db.patch(user._id, { profileBackground: args.backgroundId });
+  },
+});
+
+export const adminGrantTagline = mutation({
+  args: {
+    targetUsername: v.string(),
+    taglineId: v.string(),
+  },
+  async handler(ctx, args) {
+    const callUser = await getCurrentUser(ctx);
+    if (!callUser || !callUser.roles?.includes("developer")) return null;
+
+    const targetUser = await userByUsername(ctx, args.targetUsername);
+    if (!targetUser) return null;
+
+    if (!targetUser.unlockedProfileTaglines.includes(args.taglineId)) {
+      await ctx.db.patch(targetUser._id, {
+        unlockedProfileTaglines: [...targetUser.unlockedProfileTaglines, args.taglineId],
+      });
+    }
+  },
+});
+
+export const adminGrantBackground = mutation({
+  args: {
+    targetUsername: v.string(),
+    backgroundId: v.string(),
+  },
+  async handler(ctx, args) {
+    const callUser = await getCurrentUser(ctx);
+    if (!callUser || !callUser.roles?.includes("developer")) return null;
+
+    const targetUser = await userByUsername(ctx, args.targetUsername);
+    if (!targetUser) return null;
+
+    if (!targetUser.unlockedProfileBackgrounds.includes(args.backgroundId)) {
+      await ctx.db.patch(targetUser._id, {
+        unlockedProfileBackgrounds: [...targetUser.unlockedProfileBackgrounds, args.backgroundId],
+      });
+    }
   },
 });
 
@@ -1025,8 +1020,8 @@ async function buildUserProfile(ctx: QueryCtx, user: NonNullable<Awaited<ReturnT
     : false;
 
   // Selected tagline and background
-  const selectedTagline = await ctx.db.get(user.profileTagline);
-  const selectedBackground = await ctx.db.get(user.profileBackground);
+  const selectedTagline = PROFILE_TAGLINES_MAP[user.profileTagline] ?? null;
+  const selectedBackground = PROFILE_BACKGROUNDS_MAP[user.profileBackground] ?? null;
 
   // Ongoing game check
   const ongoingGame = await ctx.db

--- a/lib/backgrounds.ts
+++ b/lib/backgrounds.ts
@@ -1,0 +1,72 @@
+export type BackgroundTier = "starter" | "earnable" | "restricted";
+
+export interface ProfileBackground {
+  id: string;
+  title: string;
+  backgroundCSS: string;
+  tier: BackgroundTier;
+}
+
+export const PROFILE_BACKGROUNDS: ProfileBackground[] = [
+  {
+    id: "gradient-blue-green",
+    title: "Blue to Green Gradient",
+    backgroundCSS: "bg-gradient-blue-green",
+    tier: "starter",
+  },
+  {
+    id: "gradient-red-purple",
+    title: "Red to Purple Gradient",
+    backgroundCSS: "bg-gradient-red-purple",
+    tier: "starter",
+  },
+  {
+    id: "gradient-yellow-orange",
+    title: "Yellow to Orange Gradient",
+    backgroundCSS: "bg-gradient-yellow-orange",
+    tier: "starter",
+  },
+  {
+    id: "gradient-rainbow",
+    title: "Rainbow Gradient",
+    backgroundCSS: "bg-gradient-rainbow",
+    tier: "starter",
+  },
+  {
+    id: "gradient-pink-purple-royalblue",
+    title: "Pink, Purple, and Royal Blue Gradient",
+    backgroundCSS: "bg-gradient-pink-purple-royalblue",
+    tier: "starter",
+  },
+  {
+    id: "gradient-lblue-lpink-white-lpink-lblue",
+    title: "Pink, Blue, and White Gradient",
+    backgroundCSS: "bg-gradient-lblue-lpink-white-lpink-lblue",
+    tier: "starter",
+  },
+
+  {
+    id: "boulder-colorado-image",
+    title: "Boulder Colorado Hike",
+    backgroundCSS: "bg-boulder-colorado-image",
+    tier: "restricted",
+  },
+  {
+    id: "planepic-image",
+    title: "Airport Picture",
+    backgroundCSS: "bg-planepic-image",
+    tier: "restricted",
+  },
+  {
+    id: "water-gif-image",
+    title: "Animated Water",
+    backgroundCSS: "bg-water-gif-image",
+    tier: "restricted",
+  },
+];
+
+export const PROFILE_BACKGROUNDS_MAP: Record<string, ProfileBackground> = Object.fromEntries(
+  PROFILE_BACKGROUNDS.map((b) => [b.id, b])
+);
+
+export const DEFAULT_BACKGROUND_ID = "gradient-blue-green";

--- a/lib/taglines.ts
+++ b/lib/taglines.ts
@@ -1,0 +1,53 @@
+export type TaglineTier = "starter" | "earnable" | "restricted";
+
+export interface ProfileTagline {
+  id: string;
+  tagline: string;
+  tier: TaglineTier;
+}
+
+export const PROFILE_TAGLINES: ProfileTagline[] = [
+  {
+    id: "just_born",
+    tagline: "Just born!",
+    tier: "starter",
+  },
+  {
+    id: "panther_at_heart",
+    tagline: "A panther at heart",
+    tier: "starter",
+  },
+  {
+    id: "thank_you_for_driving",
+    tagline: "Thank you for driving!",
+    tier: "starter",
+  },
+
+  {
+    id: "dylandeveloper",
+    tagline: "I wish I was dylandeveloper",
+    tier: "earnable",
+  },
+  {
+    id: "hi_pookie",
+    tagline: "hi pookie",
+    tier: "earnable",
+  },
+
+  {
+    id: "hey_you",
+    tagline: "hey you, yes you. I'm talking about you.",
+    tier: "restricted",
+  },
+  {
+    id: "universe_said",
+    tagline: "and the universe said you have played the game well",
+    tier: "restricted",
+  },
+];
+
+export const PROFILE_TAGLINES_MAP: Record<string, ProfileTagline> = Object.fromEntries(
+  PROFILE_TAGLINES.map((t) => [t.id, t])
+);
+
+export const DEFAULT_TAGLINE_ID = "just_born";


### PR DESCRIPTION
## DONT MERGE AFTER APPROVAL - REQUIRES CONVEX DB PATCHES

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request migrates user profile taglines and backgrounds from using Convex document IDs to using plain string IDs defined in library files. It removes the now-deprecated `profileTaglines` and `profileBackgrounds` tables, updates all related queries and mutations, and includes a one-time migration script to convert and backfill user data. The frontend and backend have been updated to use the new string-based IDs throughout.

**Migration and Schema Updates:**

* Added a migration script (`migrateTaglinesAndBackgrounds`) to convert user profile tagline and background fields from Convex document IDs to string IDs, and to backfill all starter taglines/backgrounds into users' inventories.
* Updated the `users` table schema to use string IDs for `profileTagline`, `profileBackground`, `unlockedProfileTaglines`, and `unlockedProfileBackgrounds` instead of Convex IDs. Removed the `profileTaglines` and `profileBackgrounds` tables. [[1]](diffhunk://#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1L20-R23) [[2]](diffhunk://#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1L104-L114)

**Backend Logic Refactor:**

* Updated user creation logic to assign starter taglines/backgrounds using the new library string IDs, and to use constants from the library files for defaults. [[1]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L104-R114) [[2]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L137-R128)
* Refactored queries and mutations for fetching and updating taglines/backgrounds to use string IDs and in-memory maps (`PROFILE_TAGLINES_MAP`, `PROFILE_BACKGROUNDS_MAP`) instead of database lookups. [[1]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L431-R421) [[2]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L470-R448) [[3]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L499-R470) [[4]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L523-R496) [[5]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L549-R518)

**Frontend Type and Prop Changes:**

* Updated React component props and usages to expect string IDs for taglines and backgrounds, replacing references to Convex IDs throughout profile-related components. ([app/(users)/profile/[USERNAME]/_components/ProfileBackground.tsxL16-R25](diffhunk://#diff-0f38af9a7f8c4c5ff8cf1afb019121b2314bb4629eb83199d31c1e6bb01a5aafL16-R25), [app/(users)/profile/[USERNAME]/_components/ProfileBackground.tsxL57-R70](diffhunk://#diff-0f38af9a7f8c4c5ff8cf1afb019121b2314bb4629eb83199d31c1e6bb01a5aafL57-R70), [app/(users)/profile/[USERNAME]/page.tsxL77-R77](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L77-R77), [app/(users)/profile/[USERNAME]/page.tsxL86-R86](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L86-R86), [app/(users)/profile/[USERNAME]/page.tsxL97-R97](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L97-R97), [app/(users)/profile/[USERNAME]/page.tsxL424-R430](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L424-R430), [app/(users)/profile/[USERNAME]/page.tsxL457-R457](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L457-R457))

These changes collectively modernize the handling of user profile taglines and backgrounds, simplify data access, and prepare the codebase for future enhancements.

**Change references:** [[1]](diffhunk://#diff-10b2760f9634414b0ffa09e46ff110f2daf3578a933972f01f3eeb8caae8df92R1-R140) [[2]](diffhunk://#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1L20-R23) [[3]](diffhunk://#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1L104-L114) [[4]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L104-R114) [[5]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L137-R128) [[6]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L431-R421) [[7]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L470-R448) [[8]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L499-R470) [[9]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L523-R496) [[10]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L549-R518) [app/(users)/profile/[USERNAME]/_components/ProfileBackground.tsxL16-R25](diffhunk://#diff-0f38af9a7f8c4c5ff8cf1afb019121b2314bb4629eb83199d31c1e6bb01a5aafL16-R25), [app/(users)/profile/[USERNAME]/_components/ProfileBackground.tsxL57-R70](diffhunk://#diff-0f38af9a7f8c4c5ff8cf1afb019121b2314bb4629eb83199d31c1e6bb01a5aafL57-R70), [app/(users)/profile/[USERNAME]/page.tsxL77-R77](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L77-R77), [app/(users)/profile/[USERNAME]/page.tsxL86-R86](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L86-R86), [app/(users)/profile/[USERNAME]/page.tsxL97-R97](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L97-R97), [app/(users)/profile/[USERNAME]/page.tsxL424-R430](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L424-R430), [app/(users)/profile/[USERNAME]/page.tsxL457-R457](diffhunk://#diff-1b36e3a830739cd6114e5d4b3242d220e116ee79b7ddbc75c58b2996bdf90d75L457-R457))

### Migration Steps
After the PR merges run these two commands in order:

- [x] 1. `npx convex deploy`
- [x] 2. `npx convex run migrations:migrateTaglinesAndBackgrounds --prod`

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[improved] Customization System
[fix] Solved issue where some users didn't have all the starter backgrounds and taglines
