### PR TITLE
fix: Leaderboard loads forever do to auth issue

### DIFF
--- a/hooks/use-leaderboard.tsx
+++ b/hooks/use-leaderboard.tsx
@@ -46,7 +46,8 @@ export function useLeaderboard(type: LeaderboardType) {
     return [...topUsers, currentUser];
   }, [topUsers, currentUser, userInTop25]);
 
-  const isLoading = topUsers === undefined || currentUserProfile === undefined || (!!currentUser?.clerkId && userRank === undefined);
+  const isLoading =
+    topUsers === undefined || currentUserProfile === undefined || (!!currentUser?.clerkId && userRank === undefined);
 
   return {
     topUsers: topUsers || [],

--- a/hooks/use-leaderboard.tsx
+++ b/hooks/use-leaderboard.tsx
@@ -46,7 +46,7 @@ export function useLeaderboard(type: LeaderboardType) {
     return [...topUsers, currentUser];
   }, [topUsers, currentUser, userInTop25]);
 
-  const isLoading = topUsers === undefined || currentUserProfile === undefined || userRank === undefined;
+  const isLoading = topUsers === undefined || currentUserProfile === undefined || (!!currentUser?.clerkId && userRank === undefined);
 
   return {
     topUsers: topUsers || [],


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #213

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes a small adjustment to the loading state logic in the `useLeaderboard` hook. The change ensures that `isLoading` is only true if the current user has a `clerkId` and their rank is still undefined, preventing unnecessary loading states for users without a `clerkId`.

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[fixed] Leaderboard can now be viewed without being logged in