### PR TITLE
feat: Score and XP Modifiers

### DIFF
--- a/app/(main)/results/[leaderboardID]/page.tsx
+++ b/app/(main)/results/[leaderboardID]/page.tsx
@@ -80,6 +80,21 @@ const ResultPage = ({ params }: Props) => {
   const newLevel = leaderboardEntry ? Number(leaderboardEntry.newLevel) : 0;
   const gameType = leaderboardEntry?.gameType ?? "";
 
+  const xpBreakdown = (() => {
+    if (!leaderboardEntry) return null;
+    const baseXP = 10;
+    const pointsXP = Math.floor(finalScore / 25);
+    const spotOnCount = distances.filter((d) => d <= 20).length;
+    const spotOnXP = spotOnCount * 5;
+    const isPerfect = spotOnCount === scores.length && scores.length > 0;
+    const subtotal = (baseXP + pointsXP + spotOnXP) * (isPerfect ? 2 : 1);
+    const streak = Number(leaderboardEntry.streakAtGame ?? 0n);
+    const streakMultiplier = streak >= 14 ? 1.5 : streak >= 7 ? 1.25 : streak >= 3 ? 1.1 : 1.0;
+    const streakBonusXP = Math.floor(subtotal * streakMultiplier) - subtotal;
+    const totalXP = subtotal + streakBonusXP;
+    return { baseXP, pointsXP, spotOnXP, isPerfect, subtotal, streak, streakMultiplier, streakBonusXP, totalXP };
+  })();
+
   const router = useRouter();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [dialogContent, setDialogContent] = useState<{
@@ -267,18 +282,54 @@ const ResultPage = ({ params }: Props) => {
                   </div>
                 </div>
               ))}
-              <Separator />
               <div className="p-2">
                 <div className="flex flex-row justify-between">
                   <h2 className="font-bold">Final Score</h2>
                   <p className="bg-primary px-2 text-primary-foreground">{finalScore}</p>
                 </div>
               </div>
+              <Separator />
               <div className="p-2">
-                <div className="flex flex-row justify-between">
-                  <h2 className="font-bold">XP Awarded</h2>
-                  <p className="bg-primary px-2 text-primary-foreground">{leaderboardEntry?.xpGained || 0}</p>
+                <div className="flex flex-row justify-between pb-2">
+                  <h2 className="font-bold">XP Breakdown</h2>
                 </div>
+                {xpBreakdown && (
+                  <div className="flex flex-col space-y-1 text-sm">
+                    <div className="flex flex-row justify-between">
+                      <p className="text-muted-foreground">Base</p>
+                      <p>+{xpBreakdown.baseXP} XP</p>
+                    </div>
+                    <div className="flex flex-row justify-between">
+                      <p className="text-muted-foreground">Score bonus</p>
+                      <p>+{xpBreakdown.pointsXP} XP</p>
+                    </div>
+                    {xpBreakdown.spotOnXP > 0 && (
+                      <div className="flex flex-row justify-between">
+                        <p className="text-muted-foreground">Spot-on bonus</p>
+                        <p>+{xpBreakdown.spotOnXP} XP</p>
+                      </div>
+                    )}
+                    {xpBreakdown.isPerfect && (
+                      <div className="flex flex-row justify-between">
+                        <p className="text-muted-foreground">Perfect game</p>
+                        <p>×2</p>
+                      </div>
+                    )}
+                    {xpBreakdown.streakBonusXP > 0 && (
+                      <div className="flex flex-row justify-between">
+                        <p className="text-muted-foreground">
+                          Streak bonus ({xpBreakdown.streak}d, {Math.round((xpBreakdown.streakMultiplier - 1) * 100)}%
+                          boost)
+                        </p>
+                        <p>+{xpBreakdown.streakBonusXP} XP</p>
+                      </div>
+                    )}
+                    <div className="flex flex-row justify-between pt-1 text-base font-bold">
+                      <p>Total XP Awarded</p>
+                      <p className="bg-primary px-2 text-primary-foreground">{xpBreakdown.totalXP} XP</p>
+                    </div>
+                  </div>
+                )}
               </div>
               <Separator />
               <div className="flex flex-col space-y-4">

--- a/app/(main)/results/[leaderboardID]/page.tsx
+++ b/app/(main)/results/[leaderboardID]/page.tsx
@@ -30,6 +30,7 @@ import { api } from "@/convex/_generated/api";
 import { useCurrentUser } from "@/hooks/use-current-user";
 import useUserById from "@/hooks/use-user-by-id";
 import { cn, isValidConvexId } from "@/lib/utils";
+import { computeXPBreakdown } from "@/lib/xp";
 
 type Props = {
   params: Promise<{ leaderboardID: string }>;
@@ -80,20 +81,9 @@ const ResultPage = ({ params }: Props) => {
   const newLevel = leaderboardEntry ? Number(leaderboardEntry.newLevel) : 0;
   const gameType = leaderboardEntry?.gameType ?? "";
 
-  const xpBreakdown = (() => {
-    if (!leaderboardEntry) return null;
-    const baseXP = 10;
-    const pointsXP = Math.floor(finalScore / 25);
-    const spotOnCount = distances.filter((d) => d <= 20).length;
-    const spotOnXP = spotOnCount * 5;
-    const isPerfect = spotOnCount === scores.length && scores.length > 0;
-    const subtotal = (baseXP + pointsXP + spotOnXP) * (isPerfect ? 2 : 1);
-    const streak = Number(leaderboardEntry.streakAtGame ?? 0n);
-    const streakMultiplier = streak >= 14 ? 1.5 : streak >= 7 ? 1.25 : streak >= 3 ? 1.1 : 1.0;
-    const streakBonusXP = Math.floor(subtotal * streakMultiplier) - subtotal;
-    const totalXP = subtotal + streakBonusXP;
-    return { baseXP, pointsXP, spotOnXP, isPerfect, subtotal, streak, streakMultiplier, streakBonusXP, totalXP };
-  })();
+  const streak = leaderboardEntry ? Number(leaderboardEntry.streakAtGame ?? 0n) : 0;
+  const isFirstGameOfDay = leaderboardEntry?.firstGameOfDay ?? false;
+  const xpBreakdown = leaderboardEntry ? computeXPBreakdown(scores, distances, streak, isFirstGameOfDay) : null;
 
   const router = useRouter();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -283,7 +273,7 @@ const ResultPage = ({ params }: Props) => {
                 </div>
               ))}
               <div className="p-2">
-                <div className="flex flex-row justify-between">
+                <div className="flex flex-row justify-between font-bold">
                   <h2 className="font-bold">Final Score</h2>
                   <p className="bg-primary px-2 text-primary-foreground">{finalScore}</p>
                 </div>
@@ -299,6 +289,12 @@ const ResultPage = ({ params }: Props) => {
                       <p className="text-muted-foreground">Base</p>
                       <p>+{xpBreakdown.baseXP} XP</p>
                     </div>
+                    {xpBreakdown.firstGameOfDayXP > 0 && (
+                      <div className="flex flex-row justify-between">
+                        <p className="text-muted-foreground">First game of the day</p>
+                        <p>+{xpBreakdown.firstGameOfDayXP} XP</p>
+                      </div>
+                    )}
                     <div className="flex flex-row justify-between">
                       <p className="text-muted-foreground">Score bonus</p>
                       <p>+{xpBreakdown.pointsXP} XP</p>
@@ -318,8 +314,7 @@ const ResultPage = ({ params }: Props) => {
                     {xpBreakdown.streakBonusXP > 0 && (
                       <div className="flex flex-row justify-between">
                         <p className="text-muted-foreground">
-                          Streak bonus ({xpBreakdown.streak}d, {Math.round((xpBreakdown.streakMultiplier - 1) * 100)}%
-                          boost)
+                          Streak bonus ({streak}d, {Math.round((xpBreakdown.streakMultiplier - 1) * 100)}% boost)
                         </p>
                         <p>+{xpBreakdown.streakBonusXP} XP</p>
                       </div>

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -252,6 +252,7 @@ export const getGameById = query({
  *
  * @param {bigint[]} allPoints - An array of points earned in each game.
  * @param {bigint[]} allDistances - An array of distances for each game.
+ * @param {bigint} currentStreak - The player's current streak at the time of the game.
  * @returns {number} The total earned XP.
  *
  * @remarks
@@ -260,8 +261,16 @@ export const getGameById = query({
  * - For every 25 points earned, 1 XP is awarded.
  * - For every "Spot On" game (distance <= 20), an additional 5 XP bonus is awarded.
  * - If every round was "Spot On", the total XP is doubled.
+ * - A streak multiplier is applied: 3-6 days = 1.1x, 7-13 days = 1.25x, 14+ days = 1.5x.
  */
-function getTotalEarnedXP(allPoints: bigint[], allDistances: bigint[]): number {
+function getStreakMultiplier(streak: number): number {
+  if (streak >= 14) return 1.5;
+  if (streak >= 7) return 1.25;
+  if (streak >= 3) return 1.1;
+  return 1.0;
+}
+
+function getTotalEarnedXP(allPoints: bigint[], allDistances: bigint[], currentStreak: bigint): number {
   let earnedXP = 0;
 
   // TODO: Add 10xp if first game of the day
@@ -290,6 +299,9 @@ function getTotalEarnedXP(allPoints: bigint[], allDistances: bigint[]): number {
     earnedXP *= 2;
   }
 
+  // * Apply streak multiplier
+  earnedXP = Math.floor(earnedXP * getStreakMultiplier(Number(currentStreak)));
+
   return earnedXP;
 }
 
@@ -311,6 +323,10 @@ export const addLeaderboardEntryToGame = mutation({
     gameType: v.union(v.literal("weekly"), v.literal("singleplayer"), v.literal("multiplayer")),
   },
   handler: async (ctx, args) => {
+    // Fetch current streak before updating it (streak is updated after this)
+    const user = await ctx.db.get(args.userId);
+    const currentStreak = user?.currentStreak ?? 0n;
+
     const newXP = getTotalEarnedXP(
       [args.round_1, args.round_2, args.round_3, args.round_4, args.round_5],
       [
@@ -319,7 +335,8 @@ export const addLeaderboardEntryToGame = mutation({
         args.round_3_distance,
         args.round_4_distance,
         args.round_5_distance,
-      ]
+      ],
+      currentStreak
     );
 
     // calculate total points to update user points earned
@@ -349,6 +366,7 @@ export const addLeaderboardEntryToGame = mutation({
       round_5_distance: args.round_5_distance,
       totalTimeTaken: args.totalTimeTaken,
       xpGained: newXP,
+      streakAtGame: currentStreak,
       gameType: args.gameType,
     });
 

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 
+import { computeXPBreakdown, isNewPSTDay } from "../lib/xp";
 import { internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
 import { internalMutation, mutation, query } from "./_generated/server";
@@ -247,63 +248,6 @@ export const getGameById = query({
  * 3. Adds the new entry ID to the game's leaderboard array
  * 4. Returns success status
  */
-/**
- * Calculates the total earned experience points (XP) based on the points and distances provided.
- *
- * @param {bigint[]} allPoints - An array of points earned in each game.
- * @param {bigint[]} allDistances - An array of distances for each game.
- * @param {bigint} currentStreak - The player's current streak at the time of the game.
- * @returns {number} The total earned XP.
- *
- * @remarks
- * - Adds a base score of 10 XP for playing a game.
- * - Add 10 XP if it is the first game of the day.
- * - For every 25 points earned, 1 XP is awarded.
- * - For every "Spot On" game (distance <= 20), an additional 5 XP bonus is awarded.
- * - If every round was "Spot On", the total XP is doubled.
- * - A streak multiplier is applied: 3-6 days = 1.1x, 7-13 days = 1.25x, 14+ days = 1.5x.
- */
-function getStreakMultiplier(streak: number): number {
-  if (streak >= 14) return 1.5;
-  if (streak >= 7) return 1.25;
-  if (streak >= 3) return 1.1;
-  return 1.0;
-}
-
-function getTotalEarnedXP(allPoints: bigint[], allDistances: bigint[], currentStreak: bigint): number {
-  let earnedXP = 0;
-
-  // TODO: Add 10xp if first game of the day
-
-  // * Add score for playing a game
-  earnedXP += 10;
-
-  // * For every 25 points you get 1xp
-  let totalPointsEarned = 0;
-  for (let i = 0; i < allPoints.length; ++i) {
-    totalPointsEarned += Number(allPoints[i]);
-  }
-  earnedXP += Math.floor(totalPointsEarned / 25);
-
-  // * For every "Spot On" (distance away <= 20) add 5xp bonus
-  let numberOfSpotOnGames = 0;
-  for (let i = 0; i < allDistances.length; ++i) {
-    if (allDistances[i] <= 20) {
-      earnedXP += 5;
-      numberOfSpotOnGames++;
-    }
-  }
-
-  // * If every round was spot on, double their score
-  if (numberOfSpotOnGames == allPoints.length) {
-    earnedXP *= 2;
-  }
-
-  // * Apply streak multiplier
-  earnedXP = Math.floor(earnedXP * getStreakMultiplier(Number(currentStreak)));
-
-  return earnedXP;
-}
 
 export const addLeaderboardEntryToGame = mutation({
   args: {
@@ -323,20 +267,23 @@ export const addLeaderboardEntryToGame = mutation({
     gameType: v.union(v.literal("weekly"), v.literal("singleplayer"), v.literal("multiplayer")),
   },
   handler: async (ctx, args) => {
-    // Fetch current streak before updating it (streak is updated after this)
+    // Fetch user data before updating streak/timestamp (both are mutated after this)
     const user = await ctx.db.get(args.userId);
     const currentStreak = user?.currentStreak ?? 0n;
 
-    const newXP = getTotalEarnedXP(
-      [args.round_1, args.round_2, args.round_3, args.round_4, args.round_5],
+    const isFirstGameOfDay = isNewPSTDay(user?.lastPlayedTimestamp);
+
+    const { totalXP: newXP } = computeXPBreakdown(
+      [args.round_1, args.round_2, args.round_3, args.round_4, args.round_5].map(Number),
       [
         args.round_1_distance,
         args.round_2_distance,
         args.round_3_distance,
         args.round_4_distance,
         args.round_5_distance,
-      ],
-      currentStreak
+      ].map(Number),
+      Number(currentStreak),
+      isFirstGameOfDay
     );
 
     // calculate total points to update user points earned
@@ -367,6 +314,7 @@ export const addLeaderboardEntryToGame = mutation({
       totalTimeTaken: args.totalTimeTaken,
       xpGained: newXP,
       streakAtGame: currentStreak,
+      firstGameOfDay: isFirstGameOfDay,
       gameType: args.gameType,
     });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -85,6 +85,7 @@ export default defineSchema({
     totalTimeTaken: v.int64(),
     xpGained: v.number(),
     streakAtGame: v.optional(v.int64()),
+    firstGameOfDay: v.optional(v.boolean()),
     gameType: v.union(v.literal("weekly"), v.literal("singleplayer"), v.literal("multiplayer")),
   }).index("byUserId", ["userId"]),
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -84,6 +84,7 @@ export default defineSchema({
     round_5_distance: v.int64(),
     totalTimeTaken: v.int64(),
     xpGained: v.number(),
+    streakAtGame: v.optional(v.int64()),
     gameType: v.union(v.literal("weekly"), v.literal("singleplayer"), v.literal("multiplayer")),
   }).index("byUserId", ["userId"]),
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -6,6 +6,7 @@ import { Id } from "./_generated/dataModel";
 import { internalAction, internalMutation, mutation, MutationCtx, query, QueryCtx } from "./_generated/server";
 import { PROFILE_BACKGROUNDS, PROFILE_BACKGROUNDS_MAP, DEFAULT_BACKGROUND_ID } from "../lib/backgrounds";
 import { PROFILE_TAGLINES, PROFILE_TAGLINES_MAP, DEFAULT_TAGLINE_ID } from "../lib/taglines";
+import { isNewPSTDay } from "../lib/xp";
 
 /**
  * Retrieves a user from the database using their Convex ID.
@@ -630,24 +631,18 @@ export const updateStreak = internalMutation({
     }
 
     const now = new Date();
-    const nowPST = new Date(now.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }));
-    const lastPlay = user.lastPlayedTimestamp ? new Date(user.lastPlayedTimestamp) : new Date(0);
-    const lastPlayPST = new Date(lastPlay.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }));
-
-    // Reset time part of the dates to midnight PST
-    const nowMidnightPST = new Date(nowPST.getFullYear(), nowPST.getMonth(), nowPST.getDate());
-    const lastPlayMidnightPST = new Date(lastPlayPST.getFullYear(), lastPlayPST.getMonth(), lastPlayPST.getDate());
-
     let newStreak = user.currentStreak ?? 0n;
 
-    // Check if the user has already played today
-    if (nowMidnightPST.getTime() !== lastPlayMidnightPST.getTime()) {
+    if (isNewPSTDay(user.lastPlayedTimestamp)) {
+      const nowPST = new Date(now.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }));
+      const nowMidnightPST = new Date(nowPST.getFullYear(), nowPST.getMonth(), nowPST.getDate());
+      const lastPlay = user.lastPlayedTimestamp ? new Date(user.lastPlayedTimestamp) : new Date(0);
+      const lastPlayPST = new Date(lastPlay.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }));
+      const lastPlayMidnightPST = new Date(lastPlayPST.getFullYear(), lastPlayPST.getMonth(), lastPlayPST.getDate());
       const timeSinceLastPlay = nowMidnightPST.getTime() - lastPlayMidnightPST.getTime();
       if (timeSinceLastPlay <= 24 * 60 * 60 * 1000) {
-        // Played within the next full day, increment streak
         newStreak += 1n;
       } else {
-        // More than a full day, reset streak
         newStreak = 1n;
       }
     }

--- a/lib/xp.ts
+++ b/lib/xp.ts
@@ -1,0 +1,81 @@
+export interface XPBreakdown {
+  baseXP: number;
+  firstGameOfDayXP: number;
+  pointsXP: number;
+  spotOnXP: number;
+  isPerfect: boolean;
+  streakMultiplier: number;
+  streakBonusXP: number;
+  totalXP: number;
+}
+
+/**
+ * Returns true if `lastPlayedTimestamp` was on a different PST calendar day than now,
+ * i.e. the current game is the player's first of the day.
+ */
+export function isNewPSTDay(lastPlayedTimestamp: number | null | undefined): boolean {
+  const now = new Date();
+  const nowPST = new Date(now.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }));
+  const nowMidnight = new Date(nowPST.getFullYear(), nowPST.getMonth(), nowPST.getDate());
+
+  if (!lastPlayedTimestamp) return true;
+
+  const lastPlayPST = new Date(
+    new Date(lastPlayedTimestamp).toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
+  );
+  const lastPlayMidnight = new Date(lastPlayPST.getFullYear(), lastPlayPST.getMonth(), lastPlayPST.getDate());
+
+  return nowMidnight.getTime() !== lastPlayMidnight.getTime();
+}
+
+/**
+ * Returns the streak XP multiplier for a given streak length.
+ * - 3–6 days:  1.1× (+10%)
+ * - 7–13 days: 1.25× (+25%)
+ * - 14+ days:  1.5× (+50%)
+ */
+export function getStreakMultiplier(streak: number): number {
+  if (streak >= 14) return 1.5;
+  if (streak >= 7) return 1.25;
+  if (streak >= 3) return 1.1;
+  return 1.0;
+}
+
+/**
+ * Computes the full XP breakdown for a completed game.
+ *
+ * @param points            Array of round scores (as numbers).
+ * @param distances         Array of distances from target in feet (as numbers).
+ * @param streak            The player's streak at the time the game was completed.
+ * @param isFirstGameOfDay  Whether this is the player's first game today.
+ */
+export function computeXPBreakdown(
+  points: number[],
+  distances: number[],
+  streak: number,
+  isFirstGameOfDay: boolean
+): XPBreakdown {
+  const baseXP = 10;
+
+  // Bonus for first game of the day
+  const firstGameOfDayXP = isFirstGameOfDay ? 10 : 0;
+
+  // 1 XP per 25 points scored
+  const totalPoints = points.reduce((sum, p) => sum + p, 0);
+  const pointsXP = Math.floor(totalPoints / 25);
+
+  // 5 XP per spot-on round (distance ≤ 20 ft)
+  const spotOnCount = distances.filter((d) => d <= 20).length;
+  const spotOnXP = spotOnCount * 5;
+
+  // Perfect game: all rounds spot-on → double everything so far
+  const isPerfect = spotOnCount === points.length && points.length > 0;
+  const subtotal = (baseXP + firstGameOfDayXP + pointsXP + spotOnXP) * (isPerfect ? 2 : 1);
+
+  // Streak multiplier applied last
+  const streakMultiplier = getStreakMultiplier(streak);
+  const streakBonusXP = Math.floor(subtotal * streakMultiplier) - subtotal;
+  const totalXP = subtotal + streakBonusXP;
+
+  return { baseXP, firstGameOfDayXP, pointsXP, spotOnXP, isPerfect, streakMultiplier, streakBonusXP, totalXP };
+}


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #106
Closes #107

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request refactors and improves how experience points (XP) are calculated, stored, and displayed throughout the application. It introduces a new, detailed XP breakdown system, updates the schema and backend logic to support it, and enhances the results page UI to show users exactly how their XP was earned.

**Backend logic and calculation improvements:**

* Added a new `computeXPBreakdown` function in `lib/xp.ts` that provides a detailed, extensible breakdown of XP, including base XP, first game of the day bonus, points-based XP, spot-on bonuses, perfect game multiplier, and streak multipliers. Also added supporting helpers like `isNewPSTDay` and `getStreakMultiplier`.
* Refactored backend mutation in `convex/game.ts` to use `computeXPBreakdown` for XP calculation, replacing the old `getTotalEarnedXP` function. The mutation now also stores the user's streak and whether the game was their first of the day in the leaderboard entry. [[1]](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cL250-L294) [[2]](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cL314-R286) [[3]](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cR316-R317)
* Updated the Convex schema in `convex/schema.ts` to add optional `streakAtGame` and `firstGameOfDay` fields to leaderboard entries, enabling richer XP breakdowns and streak tracking.
* Improved streak detection logic in `convex/users.ts` by leveraging the new `isNewPSTDay` helper for more robust streak and first-game-of-day calculations. [[1]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847R9) [[2]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847R634-L650)

**Frontend and UI improvements:**

* Enhanced the results page (`app/(main)/results/[leaderboardID]/page.tsx`) to display a full XP breakdown to users, showing each XP component and how their total was calculated, including bonuses and multipliers. ([app/(main)/results/[leaderboardID]/page.tsxR33](diffhunk://#diff-e49123dbea182005ccefece36417452cde2afe7ce6c0dfda0f0b616cb11b2ffaR33), [app/(main)/results/[leaderboardID]/page.tsxR84-R87](diffhunk://#diff-e49123dbea182005ccefece36417452cde2afe7ce6c0dfda0f0b616cb11b2ffaR84-R87), [app/(main)/results/[leaderboardID]/page.tsxL270-R327](diffhunk://#diff-e49123dbea182005ccefece36417452cde2afe7ce6c0dfda0f0b616cb11b2ffaL270-R327))

These changes provide users with more transparency into their XP gains and set up the codebase for easier future enhancements to XP logic.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[New] Streaks now increase XP earned per game (3+ days: 10%, 7+ days: 25%, 14+ days: 50%)
[New] The first game of the day gives you a bonus
[New] XP Breakdown is shown on Game Results Receipt