### PR TITLE
fix: Critical Bug Fixes, Add auth & ongoing-game logic to game APIs

### DIFF
--- a/app/(main)/game/_context/GameContext.tsx
+++ b/app/(main)/game/_context/GameContext.tsx
@@ -94,7 +94,6 @@ export const GameProvider = ({ children, gameId }: { children: React.ReactNode; 
   const addLeaderboardEntryToGame = useMutation(api.game.addLeaderboardEntryToGame);
   const updateFirstPlayedBy = useMutation(api.game.updateFirstPlayedByClerkId);
   const updateOngoingGameOrCreate = useMutation(api.continuegame.updateOngoingGameOrCreate);
-  const deleteOngoingGame = useMutation(api.continuegame.deleteOngoingGame);
 
   useEffect(() => {
     if (ids) {
@@ -130,7 +129,12 @@ export const GameProvider = ({ children, gameId }: { children: React.ReactNode; 
     setIsSubmittingGuess(true);
 
     try {
-      const result = await checkGuess({ id: currentLevelId, guessLatitude: lat, guessLongitude: lng });
+      const result = await checkGuess({
+        id: currentLevelId,
+        gameId: gameData!.gameContent!._id,
+        guessLatitude: lat,
+        guessLongitude: lng,
+      });
 
       const L = (await import("leaflet")).default;
 
@@ -168,26 +172,10 @@ export const GameProvider = ({ children, gameId }: { children: React.ReactNode; 
       incrementDailyGameStats();
       incrementMonthlyGameStats();
 
-      await deleteOngoingGame({
-        gameId: gameData!.gameContent!._id,
-        userClerkId: clerkId ?? "",
-      });
-
       updateFirstPlayedBy({ clerkId: clerkId!, gameId: gameData!.gameContent!._id });
 
       addLeaderboardEntryToGame({
         gameId: gameData!.gameContent!._id,
-        userId: currentUser!.user._id,
-        round_1: BigInt(allScores[0]),
-        round_1_distance: BigInt(allDistances[0]),
-        round_2: BigInt(allScores[1]),
-        round_2_distance: BigInt(allDistances[1]),
-        round_3: BigInt(allScores[2]),
-        round_3_distance: BigInt(allDistances[2]),
-        round_4: BigInt(allScores[3]),
-        round_4_distance: BigInt(allDistances[3]),
-        round_5: BigInt(allScores[4]),
-        round_5_distance: BigInt(allDistances[4]),
         totalTimeTaken: BigInt(0),
         gameType: gameData!.gameContent!.gameType,
       }).then((leaderboardEntry) => {

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -8,6 +8,18 @@ import { mutation, query } from "./_generated/server";
  */
 export const getAllLevels = query({
   handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+
+    const callerUser = await ctx.db
+      .query("users")
+      .withIndex("byClerkId", (q) => q.eq("clerkId", identity.subject))
+      .unique();
+
+    if (!callerUser?.roles?.includes("developer") && !callerUser?.roles?.includes("moderator")) {
+      return null;
+    }
+
     // get levels and sort from newest to oldest
     const levels = await ctx.db.query("levels").collect();
     levels.sort((a, b) => (a._creationTime > b._creationTime ? -1 : 1));

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -233,13 +233,8 @@ export const getGameById = query({
  * Adds a leaderboard entry for a completed game.
  *
  * @param args.gameId - ID of the game the entry is for
- * @param args.userClerkId - Clerk ID of the user who completed the game
- * @param args.round_1 - Score for round 1
- * @param args.round_2 - Score for round 2
- * @param args.round_3 - Score for round 3
- * @param args.round_4 - Score for round 4
- * @param args.round_5 - Score for round 5
  * @param args.totalTimeTaken - Total time taken to complete all rounds
+ * @param args.gameType - The game mode that the leaderboard entry is for
  * @returns Object indicating success/failure of adding the entry
  *
  * This mutation:
@@ -252,45 +247,55 @@ export const getGameById = query({
 export const addLeaderboardEntryToGame = mutation({
   args: {
     gameId: v.id("games"),
-    userId: v.id("users"),
-    round_1: v.int64(),
-    round_1_distance: v.int64(),
-    round_2: v.int64(),
-    round_2_distance: v.int64(),
-    round_3: v.int64(),
-    round_3_distance: v.int64(),
-    round_4: v.int64(),
-    round_4_distance: v.int64(),
-    round_5: v.int64(),
-    round_5_distance: v.int64(),
     totalTimeTaken: v.int64(),
     gameType: v.union(v.literal("weekly"), v.literal("singleplayer"), v.literal("multiplayer")),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const callerUser = await ctx.db
+      .query("users")
+      .withIndex("byClerkId", (q) => q.eq("clerkId", identity.subject))
+      .unique();
+    if (!callerUser) throw new Error("User not found");
+
+    const ongoingGame = await ctx.db
+      .query("ongoingGames")
+      .withIndex("byUserClerkIdGame", (q) =>
+        q.eq("userClerkId", identity.subject).eq("game", args.gameId)
+      )
+      .first();
+
+    if (!ongoingGame?.scores || ongoingGame.scores.length !== 5) {
+      throw new Error("Game not completed — all 5 rounds must be played before submitting");
+    }
+    if (!ongoingGame.distances || ongoingGame.distances.length !== 5) {
+      throw new Error("Incomplete game data");
+    }
+
+    const [round_1, round_2, round_3, round_4, round_5] = ongoingGame.scores;
+    const [round_1_distance, round_2_distance, round_3_distance, round_4_distance, round_5_distance] =
+      ongoingGame.distances;
+
     // Fetch user data before updating streak/timestamp (both are mutated after this)
-    const user = await ctx.db.get(args.userId);
+    const user = callerUser;
     const currentStreak = user?.currentStreak ?? 0n;
 
     const isFirstGameOfDay = isNewPSTDay(user?.lastPlayedTimestamp);
 
     const { totalXP: newXP } = computeXPBreakdown(
-      [args.round_1, args.round_2, args.round_3, args.round_4, args.round_5].map(Number),
-      [
-        args.round_1_distance,
-        args.round_2_distance,
-        args.round_3_distance,
-        args.round_4_distance,
-        args.round_5_distance,
-      ].map(Number),
+      [round_1, round_2, round_3, round_4, round_5].map(Number),
+      [round_1_distance, round_2_distance, round_3_distance, round_4_distance, round_5_distance].map(Number),
       Number(currentStreak),
       isFirstGameOfDay
     );
 
     // calculate total points to update user points earned
-    const totalPointsEarned = args.round_1 + args.round_2 + args.round_3 + args.round_4 + args.round_5;
+    const totalPointsEarned = round_1 + round_2 + round_3 + round_4 + round_5;
 
     const xpResult: { newLevel: bigint; oldLevel: bigint } = await ctx.runMutation(internal.users.awardUserXP, {
-      userID: args.userId,
+      userID: callerUser._id,
       earnedXP: newXP,
       totalPointsEarned: BigInt(totalPointsEarned || 0n),
     });
@@ -300,17 +305,17 @@ export const addLeaderboardEntryToGame = mutation({
       game: args.gameId,
       oldLevel: xpResult.oldLevel,
       newLevel: xpResult.newLevel,
-      userId: args.userId,
-      round_1: args.round_1,
-      round_1_distance: args.round_1_distance,
-      round_2: args.round_2,
-      round_2_distance: args.round_2_distance,
-      round_3: args.round_3,
-      round_3_distance: args.round_3_distance,
-      round_4: args.round_4,
-      round_4_distance: args.round_4_distance,
-      round_5: args.round_5,
-      round_5_distance: args.round_5_distance,
+      userId: callerUser._id,
+      round_1,
+      round_1_distance,
+      round_2,
+      round_2_distance,
+      round_3,
+      round_3_distance,
+      round_4,
+      round_4_distance,
+      round_5,
+      round_5_distance,
       totalTimeTaken: args.totalTimeTaken,
       xpGained: newXP,
       streakAtGame: currentStreak,
@@ -330,20 +335,22 @@ export const addLeaderboardEntryToGame = mutation({
       return null;
     }
 
+    await ctx.db.delete(ongoingGame._id);
+
     // Update streak
-    await ctx.runMutation(internal.users.updateStreak, { userId: args.userId });
+    await ctx.runMutation(internal.users.updateStreak, { userId: callerUser._id });
 
     // Award achievements
-    const scores = [args.round_1, args.round_2, args.round_3, args.round_4, args.round_5];
+    const scores = [round_1, round_2, round_3, round_4, round_5];
 
     // first_steps: first completed game
     const priorEntries = await ctx.db
       .query("leaderboardEntries")
-      .withIndex("byUserId", (q) => q.eq("userId", args.userId))
+      .withIndex("byUserId", (q) => q.eq("userId", callerUser._id))
       .take(2);
     if (priorEntries.length === 1) {
       await ctx.runMutation(internal.achievements.grantAchievement, {
-        userId: args.userId,
+        userId: callerUser._id,
         achievementId: "first_steps",
       });
     }
@@ -351,7 +358,7 @@ export const addLeaderboardEntryToGame = mutation({
     // map_master: at least one perfect round (score of 250)
     if (scores.some((s) => s === 250n)) {
       await ctx.runMutation(internal.achievements.grantAchievement, {
-        userId: args.userId,
+        userId: callerUser._id,
         achievementId: "map_master",
       });
     }
@@ -359,7 +366,7 @@ export const addLeaderboardEntryToGame = mutation({
     // sniped: all 5 rounds perfect
     if (scores.every((s) => s === 250n)) {
       await ctx.runMutation(internal.achievements.grantAchievement, {
-        userId: args.userId,
+        userId: callerUser._id,
         achievementId: "sniped",
       });
     }
@@ -518,18 +525,43 @@ export const haversineDistanceInFeet = (lat1: number, lon1: number, lat2: number
  * Checks a user's guess against the correct latitude and longitude of a level
  *
  * @param args.id - The ID of the level to check against
+ * @param args.gameId - The ID of the game to check
  * @param args.guessLatitude - The user's guess for the latitude
  * @param args.guessLongitude - The user's guess for the longitude
  * @returns An object containing the correct latitude, correct longitude, distance away, and score
  */
 export const checkGuess = mutation({
-  args: { id: v.id("levels"), guessLatitude: v.float64(), guessLongitude: v.float64() },
+  args: {
+    id: v.id("levels"),
+    gameId: v.id("games"),
+    guessLatitude: v.float64(),
+    guessLongitude: v.float64(),
+  },
   handler: async (ctx, args) => {
-    const level = await ctx.db.get(args.id);
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
 
-    if (!level) {
-      throw new Error("No levels exist");
+    const game = await ctx.db.get(args.gameId);
+    if (!game) throw new Error("Game not found");
+
+    const roundIds = [game.round_1, game.round_2, game.round_3, game.round_4, game.round_5];
+    const roundIndex = roundIds.findIndex((id) => id === args.id);
+    if (roundIndex === -1) throw new Error("Level is not part of this game");
+
+    // check if this round has already been answered
+    const existingOngoingGame = await ctx.db
+      .query("ongoingGames")
+      .withIndex("byUserClerkIdGame", (q) =>
+        q.eq("userClerkId", identity.subject).eq("game", args.gameId)
+      )
+      .first();
+
+    if ((existingOngoingGame?.scores?.length ?? 0) > roundIndex) {
+      throw new Error("Already submitted a guess for this round");
     }
+
+    const level = await ctx.db.get(args.id);
+    if (!level) throw new Error("Level not found");
 
     const correctLat = level.latitude;
     const correctLng = level.longitude;
@@ -553,8 +585,29 @@ export const checkGuess = mutation({
     console.log("User Guess: " + args.guessLatitude + " " + args.guessLongitude);
 
     await ctx.db.patch(args.id, {
-      timesPlayed: (level.timesPlayed ?? BigInt(0)) + BigInt(1)
+      timesPlayed: (level.timesPlayed ?? BigInt(0)) + BigInt(1),
     });
+
+    const newScores = [...(existingOngoingGame?.scores ?? []), BigInt(score)];
+    const newDistances = [...(existingOngoingGame?.distances ?? []), BigInt(distanceAway)];
+
+    if (existingOngoingGame) {
+      await ctx.db.patch(existingOngoingGame._id, {
+        scores: newScores,
+        distances: newDistances,
+      });
+    } else {
+      // no ongoingGame yet
+      await ctx.db.insert("ongoingGames", {
+        game: args.gameId,
+        userClerkId: identity.subject,
+        currentRound: BigInt(roundIndex + 2),
+        totalTimeTaken: BigInt(0),
+        scores: newScores,
+        distances: newDistances,
+        gameType: game.gameType,
+      });
+    }
 
     return {
       correctLat,

--- a/convex/levelcreator.ts
+++ b/convex/levelcreator.ts
@@ -40,6 +40,18 @@ export const createLevelWithImageStorageId = mutation({
     tags: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const callerUser = await ctx.db
+      .query("users")
+      .withIndex("byClerkId", (q) => q.eq("clerkId", identity.subject))
+      .unique();
+
+    if (!callerUser?.roles?.includes("developer") && !callerUser?.roles?.includes("moderator")) {
+      throw new Error("Insufficient permissions");
+    }
+
     await ctx.db.insert("levels", {
       imageId: args.storageId,
       title: args.description,
@@ -100,6 +112,18 @@ export const deleteLevelById = mutation({
     levelId: v.id("levels"),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const callerUser = await ctx.db
+      .query("users")
+      .withIndex("byClerkId", (q) => q.eq("clerkId", identity.subject))
+      .unique();
+
+    if (!callerUser?.roles?.includes("developer") && !callerUser?.roles?.includes("moderator")) {
+      throw new Error("Insufficient permissions");
+    }
+
     const level = await ctx.db.get(args.levelId);
     if (level) {
       // Find all games that contain this level and delete them too

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "convex": "^1.35.1",
+        "convex": "^1.36.0",
         "date-fns": "^4.1.0",
         "heic2any": "^0.0.4",
         "html2canvas-pro": "^1.5.8",
@@ -5274,9 +5274,9 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.35.1.tgz",
-      "integrity": "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.36.0.tgz",
+      "integrity": "sha512-17cfDr2z+Apd59291rKWij6jq79eVwzY9u2MQOnuVkOsfEPXcuerWHQLf1ngXAbQjeTXD1nwQYsxQBhZnjZMIQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "convex": "^1.35.1",
+    "convex": "^1.36.0",
     "date-fns": "^4.1.0",
     "heic2any": "^0.0.4",
     "html2canvas-pro": "^1.5.8",


### PR DESCRIPTION
Holy shit we were on some bullshit when we initially coded this...

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request introduces several important improvements and security enhancements to the game logic and backend API. The main changes focus on tightening authentication and authorization, refactoring how leaderboard entries are submitted, and improving the integrity of game state updates. Below are the most significant changes grouped by theme.

**Security and Authorization Enhancements:**

* Added authentication and role-based authorization checks to level creation, deletion, and querying endpoints in `convex/levelcreator.ts` and `convex/admin.ts`, restricting these actions to users with `developer` or `moderator` roles. [[1]](diffhunk://#diff-a4bc84ac15c5d1b153cd518f84fc8d04acd16ac1dd0a77596b180e16c822a2d3R43-R54) [[2]](diffhunk://#diff-a4bc84ac15c5d1b153cd518f84fc8d04acd16ac1dd0a77596b180e16c822a2d3R115-R126) [[3]](diffhunk://#diff-c139679cee42e94b8bc300a602bddc55b29aa9b7270de7be3fc060574f65c93dR11-R22)
* Enforced authentication for critical game mutations, such as `addLeaderboardEntryToGame` and `checkGuess`, ensuring only logged-in users can perform these actions. [[1]](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cL255-R298) [[2]](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cR528-R565)

**Leaderboard and Game State Refactoring:**

* Refactored the `addLeaderboardEntryToGame` mutation to derive round scores and distances directly from the user's `ongoingGame` state, removing the need to pass them as arguments from the client and ensuring data consistency. [[1]](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cL255-R298) [[2]](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cL303-R318)
* Updated the mutation to automatically delete the user's ongoing game upon successful leaderboard entry submission, centralizing game state cleanup on the backend.

**Guess Submission Improvements:**

* Enhanced the `checkGuess` mutation to require a `gameId`, validate that the level is part of the specified game, and prevent duplicate guesses for the same round. It now updates or creates the user's `ongoingGame` state with each guess. [[1]](diffhunk://#diff-ee720b462adfb6ce798da3074c8235e7cfc4defd634fea0993e88a26f67b44aaL133-R137) [[2]](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cR528-R565) [[3]](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cL556-R610)

**Frontend Adaptations:**

* Updated the frontend to pass `gameId` when checking guesses and removed direct deletion of ongoing games, delegating this responsibility to the backend after leaderboard submission. [[1]](diffhunk://#diff-ee720b462adfb6ce798da3074c8235e7cfc4defd634fea0993e88a26f67b44aaL97) [[2]](diffhunk://#diff-ee720b462adfb6ce798da3074c8235e7cfc4defd634fea0993e88a26f67b44aaL133-R137) [[3]](diffhunk://#diff-ee720b462adfb6ce798da3074c8235e7cfc4defd634fea0993e88a26f67b44aaL171-L190)

**Dependency Update:**

* Bumped the `convex` package version from `1.35.1` to `1.36.0` in `package.json`.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[fixed]
- Fixed a bug that allowed anyone to delete levels.
- Fixed a bug that allowed score manipulation.
- Fixed a bug that allowed anyone to create levels.
- Fixed a bug that exposed level coordinates to all players.
- Fixed a bug that allowed pre-computing correct answers.