### PR TITLE
fix: Sanitize user data for public endpoints

### DIFF
--- a/app/(main)/leaderboard/_components/remaining-table.tsx
+++ b/app/(main)/leaderboard/_components/remaining-table.tsx
@@ -1,17 +1,17 @@
 import ProfileHoverCard from "@/components/profile-hover-card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Doc } from "@/convex/_generated/dataModel";
 import { LeaderboardType } from "@/convex/leaderboard";
+import { PublicUser } from "@/convex/users";
 
 type RemainingTableProps = {
-  users: Doc<"users">[];
+  users: PublicUser[];
   description: string;
   type: LeaderboardType;
-  currentUser?: Doc<"users"> | null;
+  currentUser?: PublicUser | null;
   userRank?: number | null;
 };
 
-const getStatValue = (user: Doc<"users">, type: LeaderboardType): string => {
+const getStatValue = (user: PublicUser, type: LeaderboardType): string => {
   switch (type) {
     case "streak":
       return `${user.currentStreak} day${user.currentStreak === 1n ? "" : "s"}`;
@@ -24,7 +24,7 @@ const getStatValue = (user: Doc<"users">, type: LeaderboardType): string => {
   }
 };
 
-const getSecondaryStatValue = (user: Doc<"users">, type: LeaderboardType): string => {
+const getSecondaryStatValue = (user: PublicUser, type: LeaderboardType): string => {
   switch (type) {
     case "streak":
       return `Level ${user.level}`;

--- a/app/(main)/leaderboard/_components/top-three.tsx
+++ b/app/(main)/leaderboard/_components/top-three.tsx
@@ -2,15 +2,15 @@ import ProfileHoverCard from "@/components/profile-hover-card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
-import { Doc } from "@/convex/_generated/dataModel";
 import { LeaderboardType } from "@/convex/leaderboard";
+import { PublicUser } from "@/convex/users";
 
 type TopThreeProps = {
-  users: Doc<"users">[];
+  users: PublicUser[];
   type: LeaderboardType;
 };
 
-const getStatValue = (user: Doc<"users">, type: LeaderboardType): string => {
+const getStatValue = (user: PublicUser, type: LeaderboardType): string => {
   switch (type) {
     case "streak":
       return `${user.currentStreak} day${user.currentStreak === 1n ? "" : "s"}`;

--- a/app/(users)/profile/page.tsx
+++ b/app/(users)/profile/page.tsx
@@ -8,7 +8,6 @@ import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
-import { Doc } from "@/convex/_generated/dataModel";
 import { useCurrentUser } from "@/hooks/use-current-user";
 import { useGetListOfProfiles } from "@/hooks/userProfiles/use-get-list-of-profiles";
 import { cn } from "@/lib/utils";
@@ -27,14 +26,14 @@ const ProfileSearchPage = () => {
     }
   }, [currentUser, router]);
 
-  const filteredUsernames = useMemo<Doc<"users">[]>(() => {
+  const filteredUsernames = useMemo(() => {
     if (usernames && searchedUsername) {
       return usernames.filter((user) => user.username.toLowerCase().includes(searchedUsername.toLowerCase()));
     }
     return [];
   }, [usernames, searchedUsername]);
 
-  const suggestedUsernames = useMemo<Doc<"users">[]>(() => {
+  const suggestedUsernames = useMemo(() => {
     if (usernames && searchedUsername) {
       return usernames.filter((user) => {
         const distance = Levenshtein(user.username, searchedUsername);

--- a/convex/leaderboard.ts
+++ b/convex/leaderboard.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { query } from "./_generated/server";
+import { sanitizePublicUser } from "./users";
 
 export type LeaderboardType = "streak" | "level" | "totalPoints";
 
@@ -29,7 +30,7 @@ export const getTopUsersByStreak = query({
       })
       .slice(0, 25);
 
-    return sortedUsers;
+    return sortedUsers.map(sanitizePublicUser);
   },
 });
 
@@ -59,7 +60,7 @@ export const getTopUsersByLevel = query({
       })
       .slice(0, 25);
 
-    return sortedUsers;
+    return sortedUsers.map(sanitizePublicUser);
   },
 });
 
@@ -91,7 +92,7 @@ export const getTopUsersByTotalPoints = query({
       })
       .slice(0, 25);
 
-    return sortedUsers;
+    return sortedUsers.map(sanitizePublicUser);
   },
 });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -51,6 +51,20 @@ async function userByUsername(ctx: QueryCtx | MutationCtx, username: string) {
 }
 
 /**
+ * Strips sensitive PII fields from a user document before returning it to the client.
+ * Removes: emails, banReason, banAppeal.
+ * Use for any query that may be called by users other than the account owner.
+ */
+export function sanitizePublicUser(user: NonNullable<Awaited<ReturnType<typeof userByClerkId>>>) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { emails: _emails, banReason: _banReason, banAppeal: _banAppeal, ...publicFields } = user;
+  return publicFields;
+}
+
+/** The shape of a user document safe to expose to any client. */
+export type PublicUser = ReturnType<typeof sanitizePublicUser>;
+
+/**
  * Retrieves the current user based on the authentication context.
  *
  * @param ctx - The query context containing authentication information.
@@ -187,7 +201,8 @@ export const getUserById = query({
   },
   async handler(ctx, args) {
     const user = await userById(ctx, args.id as Id<"users">);
-    return user;
+    if (!user) return null;
+    return sanitizePublicUser(user);
   },
 });
 
@@ -207,7 +222,8 @@ export const getUserByUsername = query({
   },
   async handler(ctx, args) {
     const user = await userByUsername(ctx, args.username);
-    return user;
+    if (!user) return null;
+    return sanitizePublicUser(user);
   },
 });
 
@@ -233,10 +249,20 @@ export const isUserBanned = query({
       return { result: false, banReason: undefined, appealSubmitted: false };
     }
 
+    // Only return sensitive fields (banReason, appealSubmitted) to the account owner or admins/moderators
+    const identity = await ctx.auth.getUserIdentity();
+    const isSelf = identity !== null && identity.subject === user.clerkId;
+    let isAdmin = false;
+    if (identity && !isSelf) {
+      const callerUser = await userByClerkId(ctx, identity.subject);
+      isAdmin = !!(callerUser?.roles?.includes("developer") || callerUser?.roles?.includes("moderator"));
+    }
+    const includeSensitiveData = isSelf || isAdmin;
+
     return {
       result: user.isBanned,
-      banReason: user.banReason,
-      appealSubmitted: user.banAppeal
+      banReason: includeSensitiveData ? user.banReason : undefined,
+      appealSubmitted: includeSensitiveData && user.banAppeal
         ? ((await ctx.db.get(user.banAppeal))?.hasBeenResolved === false)
         : false,
     };
@@ -572,7 +598,8 @@ export const adminGrantBackground = mutation({
 export const getListOfProfiles = query({
   args: {},
   async handler(ctx) {
-    return await ctx.db.query("users").collect();
+    const users = await ctx.db.query("users").collect();
+    return users.map(sanitizePublicUser);
   },
 });
 
@@ -994,8 +1021,15 @@ export const modifyRolesAdministrativeAction = mutation({
 /**
  * Internal helper that builds a full user profile object from a user document.
  * Used by both getUserProfile and getCurrentUserProfile to avoid duplication.
+ *
+ * @param includeSensitiveData - When true, includes banReason and appealSubmitted.
+ *   Should only be true when the caller is the account owner or an admin/moderator.
  */
-async function buildUserProfile(ctx: QueryCtx, user: NonNullable<Awaited<ReturnType<typeof userByClerkId>>>) {
+async function buildUserProfile(
+  ctx: QueryCtx,
+  user: NonNullable<Awaited<ReturnType<typeof userByClerkId>>>,
+  includeSensitiveData: boolean,
+) {
   // Derive roles from the user.roles array
   const roles = user.roles ?? [];
   const roleFlags = {
@@ -1006,13 +1040,14 @@ async function buildUserProfile(ctx: QueryCtx, user: NonNullable<Awaited<ReturnT
     isFriend: roles.includes("friend"),
   };
 
-  // Check chapman email
+  // Check chapman email without leaking the address itself
   const hasChapmanEmail = user.emails.some((email) => email.endsWith("@chapman.edu"));
 
-  // Ban status
-  const appealSubmitted = user.banAppeal
-    ? ((await ctx.db.get(user.banAppeal))?.hasBeenResolved === false)
-    : false;
+  // Ban appeal status — only fetched when the caller is allowed to see it
+  const appealSubmitted =
+    includeSensitiveData && user.banAppeal
+      ? ((await ctx.db.get(user.banAppeal))?.hasBeenResolved === false)
+      : false;
 
   // Selected tagline and background
   const selectedTagline = PROFILE_TAGLINES_MAP[user.profileTagline] ?? null;
@@ -1025,12 +1060,12 @@ async function buildUserProfile(ctx: QueryCtx, user: NonNullable<Awaited<ReturnT
     .first();
 
   return {
-    user,
+    user: sanitizePublicUser(user),
     roles: roleFlags,
     hasChapmanEmail,
     isBanned: user.isBanned,
-    banReason: user.banReason,
-    appealSubmitted,
+    banReason: includeSensitiveData ? user.banReason : undefined,
+    appealSubmitted: includeSensitiveData ? appealSubmitted : undefined,
     selectedTagline,
     selectedBackground,
     hasOngoingGame: ongoingGame !== null,
@@ -1041,6 +1076,7 @@ async function buildUserProfile(ctx: QueryCtx, user: NonNullable<Awaited<ReturnT
 /**
  * Retrieves a full user profile by Clerk ID in a single query.
  * Consolidates roles, badges, ban status, tagline, background, ongoing game, and achievements.
+ * Sensitive fields (banReason, appealSubmitted) are only returned to the account owner or admins/moderators.
  */
 export const getUserProfile = query({
   args: {
@@ -1051,13 +1087,24 @@ export const getUserProfile = query({
     if (!user) {
       return null;
     }
-    return await buildUserProfile(ctx, user);
+
+    const identity = await ctx.auth.getUserIdentity();
+    const isSelf = identity !== null && identity.subject === user.clerkId;
+
+    let isAdmin = false;
+    if (identity && !isSelf) {
+      const callerUser = await userByClerkId(ctx, identity.subject);
+      isAdmin = !!(callerUser?.roles?.includes("developer") || callerUser?.roles?.includes("moderator"));
+    }
+
+    return await buildUserProfile(ctx, user, isSelf || isAdmin);
   },
 });
 
 /**
  * Retrieves the current authenticated user's full profile in a single query.
  * Same data as getUserProfile but resolves the user via the auth token.
+ * Always includes sensitive data since this is always the account owner.
  */
 export const getCurrentUserProfile = query({
   args: {},
@@ -1066,7 +1113,7 @@ export const getCurrentUserProfile = query({
     if (!user) {
       return null;
     }
-    return await buildUserProfile(ctx, user);
+    return await buildUserProfile(ctx, user, true);
   },
 });
 

--- a/hooks/use-leaderboard.tsx
+++ b/hooks/use-leaderboard.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { useQuery } from "convex/react";
 
 import { api } from "@/convex/_generated/api";
-import { Doc } from "@/convex/_generated/dataModel";
 import { LeaderboardType } from "@/convex/leaderboard";
 import { useCurrentUser } from "./use-current-user";
 
@@ -37,7 +36,7 @@ export function useLeaderboard(type: LeaderboardType) {
 
   const userInTop25 = useMemo(() => {
     if (!topUsers || !currentUser) return false;
-    return topUsers.some((user: Doc<"users">) => user._id === currentUser._id);
+    return topUsers.some((user) => user._id === currentUser._id);
   }, [topUsers, currentUser]);
 
   const displayEntries = useMemo(() => {

--- a/hooks/use-user-by-id.tsx
+++ b/hooks/use-user-by-id.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from "convex/react";
 
 import { api } from "@/convex/_generated/api";
-import { Doc, Id } from "@/convex/_generated/dataModel";
+import { Id } from "@/convex/_generated/dataModel";
 
 const useUserById = (userId?: Id<"users">) => {
   const fetchUser = useQuery(api.users.getUserById, userId ? { id: userId } : "skip");
-  return (fetchUser ?? null) as Doc<"users"> | null;
+  return fetchUser ?? null;
 };
 
 export default useUserById;


### PR DESCRIPTION
Thanks @jkrasko-cu for finding this vulnerability!

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request introduces a new approach for handling user data privacy by ensuring that sensitive Personally Identifiable Information (PII) fields are stripped from user objects before they are returned to the client in most queries. It adds a `sanitizePublicUser` utility and a `PublicUser` type, and updates all relevant queries and UI components to use this safer type. Additionally, it restricts access to sensitive fields (such as ban reasons and appeals) so they are only visible to the account owner or admins/moderators.

**Backend: User Data Privacy and API Changes**
- Added the `sanitizePublicUser` function and `PublicUser` type in `convex/users.ts` to remove sensitive fields (emails, banReason, banAppeal) from user objects returned by most queries. Now, only non-sensitive user data is exposed to clients unless the caller is the account owner or an admin/moderator.
- Updated all relevant queries (`getUserById`, `getUserByUsername`, `getListOfProfiles`, leaderboard queries) to return `PublicUser` objects instead of full user documents. [[1]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L190-R205) [[2]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L210-R226) [[3]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L575-R602) [[4]](diffhunk://#diff-ad55ad630e46544cc2c5e817bf3bf20f9621b63aad8076087f8bf4bfb1c9b932L32-R33) [[5]](diffhunk://#diff-ad55ad630e46544cc2c5e817bf3bf20f9621b63aad8076087f8bf4bfb1c9b932L62-R63) [[6]](diffhunk://#diff-ad55ad630e46544cc2c5e817bf3bf20f9621b63aad8076087f8bf4bfb1c9b932L94-R95)
- Modified the logic for exposing sensitive fields (banReason, appealSubmitted) in user profile and ban status queries, so these are only included for the account owner or users with admin/moderator roles. [[1]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847R252-R265) [[2]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847R1024-R1032) [[3]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L1009-R1048) [[4]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L1028-R1068) [[5]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847R1079) [[6]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L1054-R1107) [[7]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L1069-R1116)

**Frontend: Type and API Usage Updates**
- Updated all frontend usages of user objects in leaderboard components (`remaining-table.tsx`, `top-three.tsx`), hooks (`use-leaderboard.tsx`, `use-user-by-id.tsx`), and profile page to use the new `PublicUser` type instead of the full `Doc<"users">` type, ensuring type safety and privacy compliance. [[1]](diffhunk://#diff-a23e3dbf2f1854797c6788ead88cd9f37d2e2df5bbecb5823a8a0c80e3ee2995L3-R14) [[2]](diffhunk://#diff-a23e3dbf2f1854797c6788ead88cd9f37d2e2df5bbecb5823a8a0c80e3ee2995L27-R27) [[3]](diffhunk://#diff-af0e7853f2c6171698a402d1b96cf4067136d5902792f6ed0956ad0d6b917d27L5-R13) [[4]](diffhunk://#diff-8c3e43814417d294d1864d07d6fb30e657965d696b0b3b545c5ec5377ed014b8L11) [[5]](diffhunk://#diff-8c3e43814417d294d1864d07d6fb30e657965d696b0b3b545c5ec5377ed014b8L30-R36) [[6]](diffhunk://#diff-16270f537811be5a9202441aa7cce36178ddb425837a1fa26176f5b022ecbc67L5) [[7]](diffhunk://#diff-16270f537811be5a9202441aa7cce36178ddb425837a1fa26176f5b022ecbc67L40-R39) [[8]](diffhunk://#diff-9cbef73236d02061739694df5e5d49ac138397983314550130ddf45c78cadc29L4-R8)

These changes collectively ensure that user privacy is respected throughout the application and that sensitive data is only available to those who are authorized to see it.

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[fix] Fixed vulnerability where emails could be accessed via public url