### PR TITLE
improved: Moved level report button

### DIFF
--- a/app/(main)/game/_components/in-game-sidebar.tsx
+++ b/app/(main)/game/_components/in-game-sidebar.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { useGame } from "../_context/GameContext";
+import ReportButton from "./report-button";
 
 import "./sidebar-cursor.css";
 
@@ -51,6 +52,7 @@ const InGameSidebar = () => {
     distanceFromTarget,
     isLoading,
     gameType,
+    currentLevelId,
   } = useGame()!;
 
   const imageLoaded = !!currentImageSrcUrl && loadedImageUrl === currentImageSrcUrl;
@@ -377,19 +379,22 @@ const InGameSidebar = () => {
               )}
             </div>
           )}
-          {isSubmittingGuess ? (
-            <Button disabled={true} className="w-full">
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> SUBMITTING
-            </Button>
-          ) : correctLocation ? (
-            <Button disabled={false} onClick={handleNextRound} className="w-full">
-              {currentRound >= levels.length ? "FINISH GAME" : "NEXT ROUND"}
-            </Button>
-          ) : (
-            <Button disabled={!markerHasBeenPlaced} className="w-full" onClick={handleSubmittingGuess}>
-              SUBMIT
-            </Button>
-          )}
+          <div className="flex gap-2">
+            {correctLocation && currentLevelId && <ReportButton levelId={currentLevelId} />}
+            {isSubmittingGuess ? (
+              <Button disabled={true} className="w-full">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" /> SUBMITTING
+              </Button>
+            ) : correctLocation ? (
+              <Button disabled={false} onClick={handleNextRound} className="w-full">
+                {currentRound >= levels.length ? "FINISH GAME" : "NEXT ROUND"}
+              </Button>
+            ) : (
+              <Button disabled={!markerHasBeenPlaced} className="w-full" onClick={handleSubmittingGuess}>
+                SUBMIT
+              </Button>
+            )}
+          </div>
         </div>
         {!isMobile && (
           <div

--- a/app/(main)/game/_components/interactable-map.tsx
+++ b/app/(main)/game/_components/interactable-map.tsx
@@ -8,19 +8,12 @@ import { MutableRefObject, useEffect, useRef, useState } from "react";
 import { CircleMarker, MapContainer, Marker, Polyline, TileLayer, useMap, useMapEvents } from "react-leaflet";
 
 import { useGame } from "../_context/GameContext";
-import ReportButton from "./report-button";
 
 import "./interactable-map.css";
 
 const InteractableMap = () => {
-  const {
-    markerHasBeenPlaced,
-    setMarkerHasBeenPlaced,
-    isSubmittingGuess,
-    setMarkerPosition,
-    correctLocation,
-    currentLevelId,
-  } = useGame()!;
+  const { markerHasBeenPlaced, setMarkerHasBeenPlaced, isSubmittingGuess, setMarkerPosition, correctLocation } =
+    useGame()!;
   const [localMarkerPosition, setLocalMarkerPosition] = useState<LatLng | null>(null);
   const prevCorrectLocation = useRef<LatLng | null>(null);
 
@@ -130,7 +123,6 @@ const InteractableMap = () => {
 
   return (
     <div className="fade-in-map relative flex min-h-full min-w-full grow">
-      {correctLocation && currentLevelId && <ReportButton levelId={currentLevelId} />}
       <MapContainer
         className="h-full w-full rounded-md"
         attributionControl={true}

--- a/app/(main)/game/_components/report-button.tsx
+++ b/app/(main)/game/_components/report-button.tsx
@@ -50,47 +50,45 @@ const ReportButton = ({ levelId }: ReportButtonProps) => {
   };
 
   return (
-    <div className="absolute right-2 top-2 z-[1000]">
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogTrigger asChild>
-          <Button variant="destructive" size="icon" className="h-8 w-8 shadow-md" title="Report this level">
-            <Flag className="h-4 w-4" />
-          </Button>
-        </DialogTrigger>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Report Level</DialogTitle>
-            <DialogDescription>Let us know what&apos;s wrong with this level so we can fix it.</DialogDescription>
-          </DialogHeader>
-          {submitted ? (
-            <div className="pt-4 text-center">
-              <p className="font-medium">Report submitted, we&apos;ll review it soon!</p>
-              <Button className="mt-4 w-full" onClick={() => handleOpenChange(false)}>
-                Close
-              </Button>
-            </div>
-          ) : (
-            <div className="flex flex-col gap-4 pt-2">
-              <Select value={selectedReason} onValueChange={(val) => setSelectedReason(val as ReportReason)}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select a reason..." />
-                </SelectTrigger>
-                <SelectContent className="z-[10002]">
-                  {REPORT_REASONS.map(({ value, label }) => (
-                    <SelectItem key={value} value={value}>
-                      {label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Button onClick={handleSubmit} disabled={!selectedReason || isSubmitting}>
-                {isSubmitting ? "Submitting..." : "Submit Report"}
-              </Button>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
-    </div>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="destructive" size="icon" className="h-10 w-10 shrink-0" title="Report this level">
+          <Flag className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Report Level</DialogTitle>
+          <DialogDescription>Let us know what&apos;s wrong with this level so we can fix it.</DialogDescription>
+        </DialogHeader>
+        {submitted ? (
+          <div className="pt-4 text-center">
+            <p className="font-medium">Report submitted, we&apos;ll review it soon!</p>
+            <Button className="mt-4 w-full" onClick={() => handleOpenChange(false)}>
+              Close
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4 pt-2">
+            <Select value={selectedReason} onValueChange={(val) => setSelectedReason(val as ReportReason)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a reason..." />
+              </SelectTrigger>
+              <SelectContent className="z-[10002]">
+                {REPORT_REASONS.map(({ value, label }) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button onClick={handleSubmit} disabled={!selectedReason || isSubmitting}>
+              {isSubmitting ? "Submitting..." : "Submit Report"}
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 };
 


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request primarily refactors the placement and usage of the `ReportButton` component within the in-game UI, improving both the user experience and code organization. The `ReportButton` is now shown contextually in the sidebar rather than overlaying the map, and its styling has been updated for consistency.

**UI/UX Improvements:**

* Moved the `ReportButton` from an absolute position overlaying the map in `interactable-map.tsx` to a contextual placement within the in-game sidebar, making it visible only when a correct location and `currentLevelId` are present. [[1]](diffhunk://#diff-3ce1440ead042c02b553bcbd68684f56338fade99c7d544af882def0e8cb5bc1R24) [[2]](diffhunk://#diff-3ce1440ead042c02b553bcbd68684f56338fade99c7d544af882def0e8cb5bc1R382-R383) [[3]](diffhunk://#diff-18d4b4711261e1eabdde5fe94a731fd431f1c5b722a87defd6bb693317f0c571L11-R16) [[4]](diffhunk://#diff-18d4b4711261e1eabdde5fe94a731fd431f1c5b722a87defd6bb693317f0c571L133)
* Updated the `ReportButton` styling to use a larger button size (`h-10 w-10`) and removed the unnecessary absolute positioning wrapper, ensuring consistent appearance within the sidebar. [[1]](diffhunk://#diff-d1f3f8df43fb0d4d8313b16f40c4e41db46c08bebce0ab05e48a144de223fb11L53-R55) [[2]](diffhunk://#diff-d1f3f8df43fb0d4d8313b16f40c4e41db46c08bebce0ab05e48a144de223fb11L93)

**Code Cleanup and Context Usage:**

* Adjusted the `useGame` context calls in both `interactable-map.tsx` and `in-game-sidebar.tsx` to only pass necessary props to each component, streamlining prop usage and reducing redundancy. [[1]](diffhunk://#diff-3ce1440ead042c02b553bcbd68684f56338fade99c7d544af882def0e8cb5bc1R55) [[2]](diffhunk://#diff-18d4b4711261e1eabdde5fe94a731fd431f1c5b722a87defd6bb693317f0c571L11-R16)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="387" height="811" alt="Screenshot 2026-04-23 at 11 48 35 AM" src="https://github.com/user-attachments/assets/200932be-e21d-4309-b5e0-27aabf8c0e52" />

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [improvement] Moved level report button for easier visibility