### PR TITLE
fix: Delete stale ongoing games by type

### DIFF
--- a/convex/continuegame.ts
+++ b/convex/continuegame.ts
@@ -9,6 +9,7 @@ import { internalMutation, mutation, query } from "./_generated/server";
 export const deleteStaleGames = internalMutation({
   args: {
     userClerkId: v.string(),
+    gameType: v.union(v.literal("weekly"), v.literal("singleplayer"), v.literal("multiplayer")),
     matchingId: v.optional(v.id("ongoingGames")),
   },
   handler: async (ctx, args) => {
@@ -17,7 +18,7 @@ export const deleteStaleGames = internalMutation({
       .withIndex("byUserClerkId", (q) => q.eq("userClerkId", args.userClerkId))
       .collect();
     for (const stale of staleGames) {
-      if (stale._id !== args.matchingId) {
+      if (stale.gameType === args.gameType && stale._id !== args.matchingId) {
         await ctx.db.delete(stale._id);
       }
     }
@@ -125,6 +126,7 @@ export const updateOngoingGameOrCreate = mutation({
     if (existingGame) {
       await ctx.scheduler.runAfter(0, internal.continuegame.deleteStaleGames, {
         userClerkId,
+        gameType,
         matchingId: existingGame._id,
       });
       await ctx.db.patch(existingGame._id, {
@@ -150,6 +152,7 @@ export const updateOngoingGameOrCreate = mutation({
       });
       await ctx.scheduler.runAfter(0, internal.continuegame.deleteStaleGames, {
         userClerkId,
+        gameType,
         matchingId: newId,
       });
     }

--- a/convex/continuegame.ts
+++ b/convex/continuegame.ts
@@ -10,7 +10,7 @@ export const deleteStaleGames = internalMutation({
   args: {
     userClerkId: v.string(),
     gameType: v.union(v.literal("weekly"), v.literal("singleplayer"), v.literal("multiplayer")),
-    matchingId: v.optional(v.id("ongoingGames")),
+    matchingId: v.id("ongoingGames"),
   },
   handler: async (ctx, args) => {
     const staleGames = await ctx.db
@@ -22,41 +22,6 @@ export const deleteStaleGames = internalMutation({
         await ctx.db.delete(stale._id);
       }
     }
-  },
-});
-
-/**
- * Creates a new save game entry in the ongoingGames table.
- * This allows users to continue their game progress later.
- *
- * @param gameId - ID of the game being saved
- * @param userClerkId - Clerk ID of the user saving the game
- * @param currentRound - The current round number (1-5) the user is on
- * @param timeLeftInRound - Optional time remaining in current round in seconds
- * @param totalTimeTaken - Total time taken across all rounds in seconds
- * @param isWeekly - Boolean indicating if the game is a weekly challenge
- *
- * @returns ID of the newly created save game entry
- */
-export const createNewSaveGame = mutation({
-  args: {
-    gameId: v.id("games"),
-    userClerkId: v.string(),
-    currentRound: v.int64(),
-    timeLeftInRound: v.optional(v.int64()),
-    totalTimeTaken: v.int64(),
-    gameType: v.union(v.literal("weekly"), v.literal("singleplayer"), v.literal("multiplayer")),
-  },
-  handler: async (ctx, args) => {
-    const { gameId, userClerkId, currentRound, timeLeftInRound, totalTimeTaken, gameType } = args;
-    await ctx.db.insert("ongoingGames", {
-      game: gameId,
-      userClerkId,
-      currentRound,
-      timeLeftInRound,
-      totalTimeTaken,
-      gameType,
-    });
   },
 });
 
@@ -228,25 +193,3 @@ export const getOngoingGameById = query({
   },
 });
 
-/**
- * Deletes all ongoing games for a user.
- * Used when a user starts a new game to delete any old ongoing games.
- *
- * @param userClerkId - The Clerk ID of the user to delete ongoing games for
- */
-export const deleteOldOngoingGames = mutation({
-  args: {
-    userClerkId: v.string(),
-  },
-  handler: async (ctx, args) => {
-    const { userClerkId } = args;
-    const ongoingGames = await ctx.db
-      .query("ongoingGames")
-      .withIndex("byUserClerkId")
-      .filter((q) => q.eq(q.field("userClerkId"), userClerkId))
-      .collect();
-    for (const game of ongoingGames) {
-      await ctx.db.delete(game._id);
-    }
-  },
-});

--- a/convex/continuegame.ts
+++ b/convex/continuegame.ts
@@ -1,6 +1,28 @@
 import { v } from "convex/values";
 
-import { mutation, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { internalMutation, mutation, query } from "./_generated/server";
+
+/**
+ * Deletes all ongoing games for a user except the one with the matching ID.
+ */
+export const deleteStaleGames = internalMutation({
+  args: {
+    userClerkId: v.string(),
+    matchingId: v.optional(v.id("ongoingGames")),
+  },
+  handler: async (ctx, args) => {
+    const staleGames = await ctx.db
+      .query("ongoingGames")
+      .withIndex("byUserClerkId", (q) => q.eq("userClerkId", args.userClerkId))
+      .collect();
+    for (const stale of staleGames) {
+      if (stale._id !== args.matchingId) {
+        await ctx.db.delete(stale._id);
+      }
+    }
+  },
+});
 
 /**
  * Creates a new save game entry in the ongoingGames table.
@@ -101,6 +123,10 @@ export const updateOngoingGameOrCreate = mutation({
       .withIndex("byUserClerkIdGame", (q) => q.eq("userClerkId", userClerkId).eq("game", gameId))
       .first();
     if (existingGame) {
+      await ctx.scheduler.runAfter(0, internal.continuegame.deleteStaleGames, {
+        userClerkId,
+        matchingId: existingGame._id,
+      });
       await ctx.db.patch(existingGame._id, {
         game: gameId,
         userClerkId,
@@ -112,7 +138,7 @@ export const updateOngoingGameOrCreate = mutation({
         gameType,
       });
     } else {
-      await ctx.db.insert("ongoingGames", {
+      const newId = await ctx.db.insert("ongoingGames", {
         game: gameId,
         userClerkId,
         currentRound,
@@ -121,6 +147,10 @@ export const updateOngoingGameOrCreate = mutation({
         scores,
         distances,
         gameType,
+      });
+      await ctx.scheduler.runAfter(0, internal.continuegame.deleteStaleGames, {
+        userClerkId,
+        matchingId: newId,
       });
     }
   },

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -603,13 +603,16 @@ export const checkGuess = mutation({
     const newDistances = [...(existingOngoingGame?.distances ?? []), BigInt(distanceAway)];
 
     if (existingOngoingGame) {
+      await ctx.scheduler.runAfter(0, internal.continuegame.deleteStaleGames, {
+        userClerkId: identity.subject,
+        matchingId: existingOngoingGame._id,
+      });
       await ctx.db.patch(existingOngoingGame._id, {
         scores: newScores,
         distances: newDistances,
       });
     } else {
-      // no ongoingGame yet
-      await ctx.db.insert("ongoingGames", {
+      const newId = await ctx.db.insert("ongoingGames", {
         game: args.gameId,
         userClerkId: identity.subject,
         currentRound: BigInt(roundIndex + 2),
@@ -617,6 +620,10 @@ export const checkGuess = mutation({
         scores: newScores,
         distances: newDistances,
         gameType: game.gameType,
+      });
+      await ctx.scheduler.runAfter(0, internal.continuegame.deleteStaleGames, {
+        userClerkId: identity.subject,
+        matchingId: newId,
       });
     }
 

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -190,7 +190,9 @@ export const createNewGame = mutation({
         .withIndex("byUserClerkId", (q) => q.eq("userClerkId", identity.subject))
         .collect();
       for (const staleGame of staleOngoingGames) {
-        await ctx.db.delete(staleGame._id);
+        if (staleGame.gameType === "singleplayer") {
+          await ctx.db.delete(staleGame._id);
+        }
       }
     }
 
@@ -605,6 +607,7 @@ export const checkGuess = mutation({
     if (existingOngoingGame) {
       await ctx.scheduler.runAfter(0, internal.continuegame.deleteStaleGames, {
         userClerkId: identity.subject,
+        gameType: game.gameType,
         matchingId: existingOngoingGame._id,
       });
       await ctx.db.patch(existingOngoingGame._id, {
@@ -623,6 +626,7 @@ export const checkGuess = mutation({
       });
       await ctx.scheduler.runAfter(0, internal.continuegame.deleteStaleGames, {
         userClerkId: identity.subject,
+        gameType: game.gameType,
         matchingId: newId,
       });
     }


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

Here I attempt this once more:

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

- This fixes an issue where past ongoing games would be left and be untouched, showing a ghost "Continue" button that doesn't actually lead you to a proper game
- This filters by game, preventing users from abusing switching from Weekly -> Single -> Weekly to attempt to get a perfect weekly challenge score.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
