### PR TITLE
improved: Add sidebar hint to make it clearer that sidebar is resizable

### DIFF
--- a/app/(main)/game/_components/in-game-sidebar.tsx
+++ b/app/(main)/game/_components/in-game-sidebar.tsx
@@ -37,6 +37,7 @@ const InGameSidebar = () => {
   const [isResetting] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [loadedImageUrl, setLoadedImageUrl] = useState("");
+  const [showResizeHint, setShowResizeHint] = useState(true);
 
   // Retrieve Game Context
   const {
@@ -65,6 +66,12 @@ const InGameSidebar = () => {
     if (isMobile && sidebarRef.current) {
       sidebarRef.current.style.width = "";
     }
+  }, [isMobile]);
+
+  useEffect(() => {
+    if (isMobile) return;
+    const timer = setTimeout(() => setShowResizeHint(false), 2000);
+    return () => clearTimeout(timer);
   }, [isMobile]);
 
   /**
@@ -435,25 +442,26 @@ const InGameSidebar = () => {
             <div
               className={cn(
                 "flex flex-col gap-1 transition-all duration-200",
-                isResizing ? "scale-110" : "group-hover:scale-110"
+                isResizing ? "scale-110" : "group-hover:scale-110",
+                showResizeHint && "resize-hint-dots"
               )}
             >
               <div
                 className={cn(
                   "h-1 w-1 rounded-full transition-colors duration-200",
-                  isResizing ? "bg-primary/80" : "bg-muted-foreground/40 group-hover:bg-primary/80"
+                  isResizing ? "bg-primary/80" : "bg-muted-foreground/60 group-hover:bg-primary/80"
                 )}
               />
               <div
                 className={cn(
                   "h-1 w-1 rounded-full transition-colors duration-200",
-                  isResizing ? "bg-primary/80" : "bg-muted-foreground/40 group-hover:bg-primary/80"
+                  isResizing ? "bg-primary/80" : "bg-muted-foreground/60 group-hover:bg-primary/80"
                 )}
               />
               <div
                 className={cn(
                   "h-1 w-1 rounded-full transition-colors duration-200",
-                  isResizing ? "bg-primary/80" : "bg-muted-foreground/40 group-hover:bg-primary/80"
+                  isResizing ? "bg-primary/80" : "bg-muted-foreground/60 group-hover:bg-primary/80"
                 )}
               />
             </div>

--- a/app/(main)/game/_components/sidebar-cursor.css
+++ b/app/(main)/game/_components/sidebar-cursor.css
@@ -1,3 +1,19 @@
 .inheritCursorOverride * {
   cursor: inherit !important;
 }
+
+@keyframes resize-dots-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  50% {
+    transform: scale(1.6);
+    opacity: 1;
+  }
+}
+
+.resize-hint-dots {
+  animation: resize-dots-pulse 0.9s ease-in-out 2;
+}


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request enhances the in-game sidebar UI by adding a visual hint to indicate the resizable area for desktop users. The hint uses an animated pulse effect on the resize dots, which appears briefly when the sidebar is first rendered and then fades out. The changes involve both React state management and new CSS animations.

**UI/UX Improvements:**

* Added a `showResizeHint` state and a `useEffect` hook in `in-game-sidebar.tsx` to display the resize hint for 2 seconds on non-mobile devices. [[1]](diffhunk://#diff-3ce1440ead042c02b553bcbd68684f56338fade99c7d544af882def0e8cb5bc1R40) [[2]](diffhunk://#diff-3ce1440ead042c02b553bcbd68684f56338fade99c7d544af882def0e8cb5bc1R71-R76)
* Updated the sidebar's resize dots to apply a new `resize-hint-dots` CSS class when the hint is active, and adjusted the muted color for better visibility.

**Styling and Animation:**

* Introduced a `resize-dots-pulse` keyframes animation and `.resize-hint-dots` class in `sidebar-cursor.css` to animate the resize dots with a pulsing effect.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="480" height="517" alt="output" src="https://github.com/user-attachments/assets/b3d1f235-2913-49e0-bf04-e6e1c0ffac17" />

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [improved] Improved clarity that the sidebar is resizable
