### PR TITLE
fix: Prevent Daily Statistics to be Manipulated 

### DIFF
--- a/app/(main)/game/_context/GameContext.tsx
+++ b/app/(main)/game/_context/GameContext.tsx
@@ -98,8 +98,6 @@ export const GameProvider = ({
   const imageSrc = useQuery(api.game.getImageSrc, currentLevelId ? { id: currentLevelId } : "skip");
   const checkGuess = useMutation(api.game.checkGuess);
 
-  const incrementDailyGameStats = useMutation(api.gamestats.incrementDailyGameStats);
-  const incrementMonthlyGameStats = useMutation(api.gamestats.incrementMonthlyGameStats);
   const addLeaderboardEntryToGame = useMutation(api.game.addLeaderboardEntryToGame);
   const updateFirstPlayedBy = useMutation(api.game.updateFirstPlayedByClerkId);
   const updateOngoingGameOrCreate = useMutation(api.continuegame.updateOngoingGameOrCreate);
@@ -174,9 +172,6 @@ export const GameProvider = ({
     if (nextRoundNumber > levels.length) {
       setIsLoading(true);
       setIsModalVisible(true);
-
-      incrementDailyGameStats();
-      incrementMonthlyGameStats();
 
       updateFirstPlayedBy({ clerkId: clerkId!, gameId: gameData!.gameContent!._id });
 

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -350,6 +350,9 @@ export const addLeaderboardEntryToGame = mutation({
 
     await ctx.db.delete(ongoingGame._id);
 
+    await ctx.runMutation(internal.gamestats.incrementDailyGameStats);
+    await ctx.runMutation(internal.gamestats.incrementMonthlyGameStats);
+
     // Update streak
     await ctx.runMutation(internal.users.updateStreak, { userId: callerUser._id });
 

--- a/convex/gamestats.ts
+++ b/convex/gamestats.ts
@@ -2,7 +2,7 @@
 
 import { v } from "convex/values";
 
-import { mutation, query } from "./_generated/server";
+import { internalMutation, query } from "./_generated/server";
 
 /**
  * Retrieves the daily game statistics from the database.
@@ -62,7 +62,7 @@ export const getPastNDaysOfStats = query({
  * @param ctx - The context object containing the database instance.
  * @returns A promise that resolves to a BigInt value of 0.
  */
-export const createDailyGameStats = mutation({
+export const createDailyGameStats = internalMutation({
   handler: async (ctx) => {
     const date = new Date();
     await ctx.db.insert("gameStats", {
@@ -88,7 +88,7 @@ export const createDailyGameStats = mutation({
  * @param {Object} ctx - The context object containing the database connection.
  * @returns {Promise<bigint>} - The updated count of daily game statistics.
  */
-export const incrementDailyGameStats = mutation({
+export const incrementDailyGameStats = internalMutation({
   handler: async (ctx) => {
     const date = new Date();
     const today = date.toISOString().split("T")[0];
@@ -149,7 +149,7 @@ export const getMonthlyGameStats = query({
   },
 });
 
-export const createMonthlyGameStats = mutation({
+export const createMonthlyGameStats = internalMutation({
   handler: async (ctx) => {
     const date = new Date();
     await ctx.db.insert("gameStats", {
@@ -164,7 +164,7 @@ export const createMonthlyGameStats = mutation({
   },
 });
 
-export const incrementMonthlyGameStats = mutation({
+export const incrementMonthlyGameStats = internalMutation({
   handler: async (ctx) => {
     const date = new Date();
     const isoYearMonth = date.toISOString().split("-")[0] + "-" + date.toISOString().split("-")[1];


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request refactors how daily and monthly game statistics are updated by moving the increment logic from the frontend to the backend, and by making related mutations internal-only for improved encapsulation and security. The changes ensure that statistics are updated atomically as part of the leaderboard entry mutation, reducing the risk of inconsistencies and simplifying the frontend logic.

**Backend logic and encapsulation improvements:**

* Changed `incrementDailyGameStats`, `incrementMonthlyGameStats`, `createDailyGameStats`, and `createMonthlyGameStats` in `convex/gamestats.ts` from public `mutation` to `internalMutation`, restricting their access to internal backend calls only. [[1]](diffhunk://#diff-9610a047c42ad2ef26ce56b769c05a6bc86762680a3bbd35b1423801ce5bc134L5-R5) [[2]](diffhunk://#diff-9610a047c42ad2ef26ce56b769c05a6bc86762680a3bbd35b1423801ce5bc134L65-R65) [[3]](diffhunk://#diff-9610a047c42ad2ef26ce56b769c05a6bc86762680a3bbd35b1423801ce5bc134L91-R91) [[4]](diffhunk://#diff-9610a047c42ad2ef26ce56b769c05a6bc86762680a3bbd35b1423801ce5bc134L152-R152) [[5]](diffhunk://#diff-9610a047c42ad2ef26ce56b769c05a6bc86762680a3bbd35b1423801ce5bc134L167-R167)
* Moved the calls to increment daily and monthly game stats from the frontend (`GameContext.tsx`) to the backend by invoking them within the `addLeaderboardEntryToGame` mutation in `convex/game.ts`.

**Frontend simplification:**

* Removed the direct calls to `incrementDailyGameStats` and `incrementMonthlyGameStats` mutations from the `GameProvider` component in `GameContext.tsx`, as these are now handled server-side. [[1]](diffhunk://#diff-ee720b462adfb6ce798da3074c8235e7cfc4defd634fea0993e88a26f67b44aaL101-L102) [[2]](diffhunk://#diff-ee720b462adfb6ce798da3074c8235e7cfc4defd634fea0993e88a26f67b44aaL178-L180)

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[fix] Fixed an issue where game play counts could be manipulated from outside the game (Thanks Jeffrey)
[fix] Game stats now only update when a real game is actually completed