### PR TITLE
fix: Enforce authentication for game page and image

### DIFF
--- a/app/(main)/game/[GAMEID]/page.tsx
+++ b/app/(main)/game/[GAMEID]/page.tsx
@@ -62,7 +62,13 @@ const GameIdPage = ({ params }: Props) => {
 
   const gameExists = useQuery(api.game.gameExists, gameIdAsId ? { gameId: gameIdAsId } : "skip");
 
-  const { data: currentUser } = useCurrentUser();
+  const { data: currentUser, isLoading: isUserLoading, isAuthenticated } = useCurrentUser();
+
+  useEffect(() => {
+    if (!isUserLoading && !isAuthenticated) {
+      router.push("/");
+    }
+  }, [isUserLoading, isAuthenticated, router]);
 
   useEffect(() => {
     if (currentUser?.isBanned) {

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -470,6 +470,9 @@ export const getLeaderboardEntryByGameAndUser = query({
 export const getImageSrc = query({
   args: { id: v.id("levels") },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
     if (!args.id) {
       throw new Error("Missing entryId parameter.");
     }


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #287

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request introduces improvements to authentication handling in both the frontend and backend to ensure that only authenticated users can access certain pages and API endpoints. The key changes are as follows:

**Frontend authentication and routing:**

* Added checks in `GameIdPage` (`app/(main)/game/[GAMEID]/page.tsx`) to redirect unauthenticated users to the home page by using `isAuthenticated` and `isUserLoading` from `useCurrentUser`. ([app/(main)/game/[GAMEID]/page.tsxL65-R71](diffhunk://#diff-86975e5fa72147b6d2cd3de4e9118f824cd945f9fec86a883fff3f5411b582dcL65-R71))

**Backend authentication enforcement:**

* Updated the `getImageSrc` query in `convex/game.ts` to throw an error if the user is not authenticated by checking the user identity at the start of the handler.

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [fix] Fixed an issue where game images could be accessed without signing in (Thanks Joel!)
