### PR TITLE
[add] Stack Logo on Mobile

### DIFF
--- a/app/(main)/tournament/[ROOMCODE]/_components/game-over-screen.tsx
+++ b/app/(main)/tournament/[ROOMCODE]/_components/game-over-screen.tsx
@@ -40,7 +40,7 @@ export function SpectatorGameOver({
         </Button>
       </Link>
       <div className="flex flex-row items-center gap-2 pb-4">
-        <Logo logoDimensions={100} textOptions="text-3xl" badge="Tournament" />
+        <Logo logoDimensions={100} textOptions="text-2xl" badge="Tournament" stackOnMobile={true} />
       </div>
       <div className="flex items-center gap-12">
         <div className="flex flex-col items-center gap-3">

--- a/app/(main)/tournament/[ROOMCODE]/_components/spectator-header.tsx
+++ b/app/(main)/tournament/[ROOMCODE]/_components/spectator-header.tsx
@@ -25,7 +25,7 @@ export function SpectatorHeader({
       <PlayerSlot clerkId={room.player1ClerkId} label="Player 1" users={users} status={p1Status} color="p1color" />
       <div className="flex flex-col items-center">
         <div className="flex flex-row items-center gap-2">
-          <Logo logoDimensions={100} textOptions="text-3xl" badge="Tournament" />
+          <Logo logoDimensions={100} textOptions="text-2xl" badge="Tournament" stackOnMobile={true} />
         </div>
         <span className="text-sm text-muted-foreground">Round {room.currentRound}/5</span>
       </div>

--- a/app/(main)/tournament/[ROOMCODE]/_components/waiting-lobby.tsx
+++ b/app/(main)/tournament/[ROOMCODE]/_components/waiting-lobby.tsx
@@ -47,7 +47,7 @@ export function SpectatorWaitingLobby({
         </Button>
       </Link>
       <div className="flex flex-row items-center gap-2">
-        <Logo logoDimensions={100} textOptions="text-3xl" badge="Tournament" />
+        <Logo logoDimensions={100} textOptions="text-2xl" badge="Tournament" stackOnMobile={true} />
       </div>
 
       <div className="text-center">

--- a/app/(main)/tournament/play/[ROOMCODE]/_components/player-game-over.tsx
+++ b/app/(main)/tournament/play/[ROOMCODE]/_components/player-game-over.tsx
@@ -38,7 +38,7 @@ export function PlayerGameOver({
       <Navbar />
       <div className="flex flex-1 flex-col items-center justify-center gap-6 px-4 pt-24 text-center">
         <div className="flex flex-row items-center gap-2 pb-4">
-          <Logo logoDimensions={100} textOptions="text-3xl" badge="Tournament" />
+          <Logo logoDimensions={100} textOptions="text-2xl" badge="Tournament" stackOnMobile={true} />
         </div>
         <div className="flex items-center gap-12">
           <div className="flex flex-col items-center gap-3">

--- a/app/(main)/tournament/play/[ROOMCODE]/_components/waiting-screen.tsx
+++ b/app/(main)/tournament/play/[ROOMCODE]/_components/waiting-screen.tsx
@@ -60,7 +60,7 @@ export function WaitingScreen({
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8 px-4 text-center">
       <div className="flex flex-row items-center gap-2">
-        <Logo logoDimensions={100} textOptions="text-3xl" badge="Tournament" />
+        <Logo logoDimensions={100} textOptions="text-2xl" badge="Tournament" stackOnMobile={true} />
       </div>
       <h1 className="text-2xl font-bold">Room {roomCode}</h1>
       <div className="flex gap-12">

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -16,20 +16,22 @@ interface LogoProps {
   badge?: string;
   logoDimensions?: number;
   textOptions?: string;
+  stackOnMobile?: boolean;
 }
 
-export const Logo = ({ href, as_png, badge, logoDimensions = 40, textOptions }: LogoProps) => {
+export const Logo = ({ href, as_png, badge, logoDimensions = 40, textOptions, stackOnMobile = false }: LogoProps) => {
   const logoContent = (
     <div className="flex items-center gap-x-2">
-      <Image
-        draggable={false}
-        src={as_png ? "/pantherguessr_logo.png" : "/pantherguessr_logo.svg"}
-        height={logoDimensions}
-        width={logoDimensions}
-        alt="Logo"
-        className="select-none"
-      />
-      <p className={cn("select-none pl-2 pr-2 font-semibold", font.className, textOptions)}>PantherGuessr</p>
+        <Image
+          draggable={false}
+          src={as_png ? "/pantherguessr_logo.png" : "/pantherguessr_logo.svg"}
+          height={logoDimensions}
+          width={logoDimensions}
+          alt="Logo"
+          className="select-none"
+        />
+      <div className={cn("flex items-center justify-center gap-x-2", stackOnMobile ? "flex-col gap-y-1 sm:flex-row" : "")}>
+        <p className={cn("select-none pl-2 pr-2 font-semibold", font.className, textOptions)}>PantherGuessr</p>
       {badge && (
         <Badge
           className={cn(
@@ -40,6 +42,7 @@ export const Logo = ({ href, as_png, badge, logoDimensions = 40, textOptions }: 
           {badge}
         </Badge>
       )}
+      </div>
     </div>
   );
 

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -22,26 +22,28 @@ interface LogoProps {
 export const Logo = ({ href, as_png, badge, logoDimensions = 40, textOptions, stackOnMobile = false }: LogoProps) => {
   const logoContent = (
     <div className="flex items-center gap-x-2">
-        <Image
-          draggable={false}
-          src={as_png ? "/pantherguessr_logo.png" : "/pantherguessr_logo.svg"}
-          height={logoDimensions}
-          width={logoDimensions}
-          alt="Logo"
-          className="select-none"
-        />
-      <div className={cn("flex items-center justify-center gap-x-2", stackOnMobile ? "flex-col gap-y-1 sm:flex-row" : "")}>
+      <Image
+        draggable={false}
+        src={as_png ? "/pantherguessr_logo.png" : "/pantherguessr_logo.svg"}
+        height={logoDimensions}
+        width={logoDimensions}
+        alt="Logo"
+        className="select-none"
+      />
+      <div
+        className={cn("flex items-center justify-center gap-x-2", stackOnMobile ? "flex-col gap-y-1 sm:flex-row" : "")}
+      >
         <p className={cn("select-none pl-2 pr-2 font-semibold", font.className, textOptions)}>PantherGuessr</p>
-      {badge && (
-        <Badge
-          className={cn(
-            href == undefined ? "cursor-default hover:bg-red-800" : "cursor-pointer hover:bg-red-900",
-            "h-6 select-none bg-red-800 pt-1 text-white"
-          )}
-        >
-          {badge}
-        </Badge>
-      )}
+        {badge && (
+          <Badge
+            className={cn(
+              href == undefined ? "cursor-default hover:bg-red-800" : "cursor-pointer hover:bg-red-900",
+              "h-6 select-none bg-red-800 pt-1 text-white"
+            )}
+          >
+            {badge}
+          </Badge>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

- Added an option to enable stacking the logo contents on mobile to prevent horizontal overflow

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[fixed] Mobile logo layout for tournament