### PR TITLE
fix: fix `game:ClearOldGames` failing to fire

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -7,19 +7,19 @@ const crons = cronJobs();
 
 crons.daily(
   "Reset inactive streaks",
-  { hourUTC: 8, minuteUTC: 0 }, // 12:00am PST
+  { hourUTC: 8, minuteUTC: 0 }, // 12:00am PST and 1:00am PDT
   internal.users.resetInactiveStreaks
 );
 
 crons.daily(
   "Clear old games",
-  { hourUTC: 8, minuteUTC: 0 }, // 12:00am PST
+  { hourUTC: 8, minuteUTC: 0 }, // 12:00am PST and 1:00am PDT
   internal.game.clearOldGames
 );
 
 crons.daily(
   "Clear unplayed games",
-  { hourUTC: 8, minuteUTC: 0 }, // 12:00am PST
+  { hourUTC: 8, minuteUTC: 0 }, // 12:00am PST and 1:00am PDT
   internal.game.clearUnplayedGames
 );
 

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -112,27 +112,23 @@ export const clearOldGames = internalMutation({
       // get the connected leaderboard IDs, if applicable
       const leaderboardIds = game.leaderboard ?? [];
       for (const leaderboardId of leaderboardIds) {
-        await ctx.db.delete(leaderboardId);
+        if (await ctx.db.get(leaderboardId)) {
+          await ctx.db.delete(leaderboardId);
+        }
       }
 
-      // get any connected ongoing games, if applicable
-      await ctx.db
+      const ongoingGames = await ctx.db
         .query("ongoingGames")
         .filter((q) => q.eq(q.field("game"), game._id))
-        .collect()
-        .then(
-          // delete the ongoing games
-          async (ongoingGames) => {
-            for (const ongoingGame of ongoingGames) {
-              await ctx.db.delete(ongoingGame._id);
-            }
-          }
-        );
-      // delete game
-      await ctx.db.delete(game._id);
+        .collect();
+      for (const ongoingGame of ongoingGames) {
+        await ctx.db.delete(ongoingGame._id);
+      }
 
-      return `Deleted ${games.length} games`;
+      await ctx.db.delete(game._id);
     }
+
+    return `Deleted ${games.length} games`;
   },
 });
 


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #292

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes improvements to the daily cron job schedule comments and optimizes the deletion logic for old games and their related data. The main changes clarify the time zone handling for cron jobs and ensure safer, more efficient deletion of related leaderboard and ongoing game records.

**Cron job schedule clarification:**

* Updated comments for daily cron jobs in `convex/crons.ts` to indicate that jobs run at 12:00am PST and 1:00am PDT, clarifying the time zone handling.

**Game deletion logic improvements:**

* In `convex/game.ts`, added a check to ensure a leaderboard exists before attempting to delete it, preventing potential errors.
* Refactored the deletion of ongoing games to first collect all related records, then delete them in a loop, improving clarity and reliability.

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: n/a
