### PR TITLE
fix: Force Game Image to Renders at Max Sidebar Width

### DIFF
--- a/app/(main)/game/_components/in-game-sidebar.tsx
+++ b/app/(main)/game/_components/in-game-sidebar.tsx
@@ -405,7 +405,7 @@ const InGameSidebar = () => {
               <Image
                 src={currentImageSrcUrl}
                 fill
-                sizes={isMobile ? "250px" : "600px"}
+                sizes={isMobile ? "250px" : `${SIDEBAR_MAX_WIDTH_CAP}px`}
                 alt=""
                 onLoad={() => setLoadedImageUrl(currentImageSrcUrl)}
                 onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->


## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes a small adjustment to the `InGameSidebar` component to improve how image sizing is handled on non-mobile devices.

* Updated the `sizes` prop for the `Image` component to use the `SIDEBAR_MAX_WIDTH_CAP` constant instead of a hardcoded value, ensuring consistent image sizing with the sidebar's maximum width.

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [fix] Fix issue where image would be blurry in games
