### PR TITLE
fix: Only show people w/ a streak on streak leaderboard

### DIFF
--- a/app/(main)/leaderboard/_components/remaining-table.tsx
+++ b/app/(main)/leaderboard/_components/remaining-table.tsx
@@ -86,58 +86,64 @@ export function RemainingTable({ users, type, description, currentUser, userRank
       <h3 className="mb-2 hidden text-xl font-semibold md:block">Full Rankings</h3>
       <p className="text-muted-foreground mb-4">{description}</p>
 
-      <Table className="w-full border-collapse">
-        <TableHeader>
-          <TableRow>
-            <TableHead className="p-2 text-center">Rank</TableHead>
-            <TableHead className="p-2">User</TableHead>
-            <TableHead className={`p-2 ${getAlignmentClass(type)[0]}`}>{statHeader}</TableHead>
-            <TableHead className={`p-2 ${getAlignmentClass(type)[1]}`}>{secondaryStatHeader}</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {users.map((user, index) => {
-            const rank = index + 1;
-            const isCurrentUser = currentUser && user._id === currentUser._id;
-            const isAppendedBeyondTop = isCurrentUser && userRank && userRank > index + 1;
-            const displayRank = isAppendedBeyondTop ? userRank : rank;
+      {users.length === 0 ? (
+        <div className="py-12 text-center">
+          <p className="text-muted-foreground">No one has an active streak right now. Be the first!</p>
+        </div>
+      ) : (
+        <Table className="w-full border-collapse">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="p-2 text-center">Rank</TableHead>
+              <TableHead className="p-2">User</TableHead>
+              <TableHead className={`p-2 ${getAlignmentClass(type)[0]}`}>{statHeader}</TableHead>
+              <TableHead className={`p-2 ${getAlignmentClass(type)[1]}`}>{secondaryStatHeader}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((user, index) => {
+              const rank = index + 1;
+              const isCurrentUser = currentUser && user._id === currentUser._id;
+              const isAppendedBeyondTop = isCurrentUser && userRank && userRank > index + 1;
+              const displayRank = isAppendedBeyondTop ? userRank : rank;
 
-            return (
-              <>
-                {isAppendedBeyondTop && (
-                  <TableRow key="separator">
-                    <TableCell colSpan={4} className="text-muted-foreground py-1 text-center">
-                      &middot;&middot;&middot;
+              return (
+                <>
+                  {isAppendedBeyondTop && (
+                    <TableRow key="separator">
+                      <TableCell colSpan={4} className="text-muted-foreground py-1 text-center">
+                        &middot;&middot;&middot;
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  <TableRow key={user._id} className={isCurrentUser ? "bg-red-600/10 dark:bg-red-600/30" : ""}>
+                    <TableCell className="p-2 text-center font-semibold">
+                      {displayRank <= 3 ? (
+                        <span className="text-lg">
+                          {displayRank === 1 && "🥇"}
+                          {displayRank === 2 && "🥈"}
+                          {displayRank === 3 && "🥉"}
+                        </span>
+                      ) : (
+                        displayRank
+                      )}
+                    </TableCell>
+                    <TableCell className="p-2 text-start">
+                      <ProfileHoverCard userID={user._id} />
+                    </TableCell>
+                    <TableCell className={`p-2 font-semibold ${getAlignmentClass(type)[0]}`}>
+                      {getStatValue(user, type)}
+                    </TableCell>
+                    <TableCell className={`text-muted-foreground p-2 ${getAlignmentClass(type)[1]}`}>
+                      {getSecondaryStatValue(user, type)}
                     </TableCell>
                   </TableRow>
-                )}
-                <TableRow key={user._id} className={isCurrentUser ? "bg-red-600/10 dark:bg-red-600/30" : ""}>
-                  <TableCell className="p-2 text-center font-semibold">
-                    {displayRank <= 3 ? (
-                      <span className="text-lg">
-                        {displayRank === 1 && "🥇"}
-                        {displayRank === 2 && "🥈"}
-                        {displayRank === 3 && "🥉"}
-                      </span>
-                    ) : (
-                      displayRank
-                    )}
-                  </TableCell>
-                  <TableCell className="p-2 text-start">
-                    <ProfileHoverCard userID={user._id} />
-                  </TableCell>
-                  <TableCell className={`p-2 font-semibold ${getAlignmentClass(type)[0]}`}>
-                    {getStatValue(user, type)}
-                  </TableCell>
-                  <TableCell className={`text-muted-foreground p-2 ${getAlignmentClass(type)[1]}`}>
-                    {getSecondaryStatValue(user, type)}
-                  </TableCell>
-                </TableRow>
-              </>
-            );
-          })}
-        </TableBody>
-      </Table>
+                </>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
     </div>
   );
 }

--- a/app/(main)/leaderboard/_components/top-three.tsx
+++ b/app/(main)/leaderboard/_components/top-three.tsx
@@ -41,11 +41,7 @@ export function TopThree({ users, type }: TopThreeProps) {
   // const statLabel = getStatLabel(type);
 
   if (topThree.length === 0) {
-    return (
-      <div className="py-8 text-center">
-        <p className="text-muted-foreground">No users found for this leaderboard.</p>
-      </div>
-    );
+    return null;
   }
 
   return (

--- a/app/(main)/leaderboard/page.tsx
+++ b/app/(main)/leaderboard/page.tsx
@@ -38,6 +38,10 @@ export default function LeaderboardPage() {
 
   const selectedTypeInfo = LEADERBOARD_TYPES.find((t) => t.key === selectedType);
 
+  const filteredTopUsers = selectedType === "streak" ? topUsers.filter((u) => u.currentStreak > 0n) : topUsers;
+  const filteredDisplayEntries =
+    selectedType === "streak" ? displayEntries.filter((u) => u.currentStreak > 0n) : displayEntries;
+
   return (
     <div className="flex h-full min-h-screen w-screen flex-col justify-between">
       <div className="mx-auto w-full max-w-6xl px-4 py-8">
@@ -68,11 +72,11 @@ export default function LeaderboardPage() {
                 ) : (
                   <>
                     {/* Top 3 Users Display */}
-                    <TopThree users={topUsers} type={selectedType} />
+                    <TopThree users={filteredTopUsers} type={selectedType} />
 
                     {/* Full Rankings Table */}
                     <RemainingTable
-                      users={displayEntries}
+                      users={filteredDisplayEntries}
                       description={selectedTypeInfo?.description || ""}
                       type={selectedType}
                       currentUser={currentUser}
@@ -80,14 +84,19 @@ export default function LeaderboardPage() {
                     />
 
                     {/* User's Current Rank Display */}
-                    {userRank !== null && userRank > 0 && (
-                      <div className="mt-6 text-center">
-                        <div className="bg-muted inline-block rounded-lg p-4">
-                          <p className="text-muted-foreground mb-1 text-sm">Your Current Rank</p>
-                          <p className="text-2xl font-bold">#{userRank}</p>
+                    {userRank !== null &&
+                      userRank > 0 &&
+                      !(
+                        selectedType === "streak" &&
+                        (!currentUser?.currentStreak || currentUser.currentStreak === 0n)
+                      ) && (
+                        <div className="mt-6 text-center">
+                          <div className="bg-muted inline-block rounded-lg p-4">
+                            <p className="text-muted-foreground mb-1 text-sm">Your Current Rank</p>
+                            <p className="text-2xl font-bold">#{userRank}</p>
+                          </div>
                         </div>
-                      </div>
-                    )}
+                      )}
 
                     {/* No rank message */}
                     {userRank === -1 && (

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm",
+      "ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground inline-flex cursor-pointer items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm",
       className
     )}
     {...props}
@@ -52,4 +52,4 @@ const TabsContent = React.forwardRef<
 ));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsContent, TabsList, TabsTrigger };


### PR DESCRIPTION
<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/PantherGuessr/PantherGuessr/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of PantherGuessr.
- [x] I have tested these changes locally on my machine.

<!--
What PantherGuessr issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request improves the leaderboard user experience by refining how users with active streaks are displayed and enhancing messaging for empty states. It also includes a minor UI improvement for tab navigation.

Leaderboard logic and display improvements:
* The leaderboard now only shows users with an active streak in both the top users and the rankings table when the "streak" leaderboard is selected. This ensures that inactive users do not appear in streak-based rankings. [[1]](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562R41-R44) [[2]](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L71-R92)
* The "Your Current Rank" section is now hidden for the streak leaderboard if the current user does not have an active streak, preventing confusing or irrelevant rank displays.
* When there are no users with an active streak, the rankings table now displays a friendly message encouraging participation, and the top-three section is hidden if empty. [[1]](diffhunk://#diff-a23e3dbf2f1854797c6788ead88cd9f37d2e2df5bbecb5823a8a0c80e3ee2995R89-R93) [[2]](diffhunk://#diff-a23e3dbf2f1854797c6788ead88cd9f37d2e2df5bbecb5823a8a0c80e3ee2995R146) [[3]](diffhunk://#diff-af0e7853f2c6171698a402d1b96cf4067136d5902792f6ed0956ad0d6b917d27L44-R44)

UI and accessibility enhancements:
* The leaderboard tabs are now explicitly styled with a `cursor-pointer` for better usability and visual feedback.
* The export order of tab components was updated for consistency, though this does not impact functionality.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="608" height="328" alt="image" src="https://github.com/user-attachments/assets/d9be4cf4-f164-420e-91c2-aeeff89cc198" />

## Release notes

<!--
Add your release notes.
[category] = [added, fixed, improved, or removed]
E.g., Notes: [category] Release Note Title Here
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [fix] Players with no active streak are now hidden from the Longest Streak leaderboard
